### PR TITLE
[feat] 카카오 로그인1 - OAuth 토큰 발급 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,13 +23,13 @@ ext {
 
 dependencies {
 	// QueryDSL
-	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
-	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	//implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+	//annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	//annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	//annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 
 	// Spring Boot Starters
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -37,7 +37,7 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	// DB
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	//runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -69,6 +69,15 @@ dependencies {
 	implementation 'org.apache.commons:commons-lang3:3.13.0'
 	implementation 'commons-io:commons-io:2.11.0'
 
+	// WebClient (카카오 API 호출용)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// Redis (ElastiCache 연동용)
+	//implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Actuator (헬스체크용 - ALB/배포 환경에서 필요)
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
@@ -77,4 +86,19 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// .env 파일 로드
+tasks.named('bootRun') {
+	doFirst {
+		def envFile = file('.env')
+		if (envFile.exists()) {
+			envFile.readLines().each {
+				def (key, value) = it.tokenize('=')
+				if (key && value) {
+					environment key, value
+				}
+			}
+		}
+	}
 }

--- a/src/main/java/com/waytoearth/config/SecurityConfig.java
+++ b/src/main/java/com/waytoearth/config/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.waytoearth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+//                        .requestMatchers("/v1/auth/**").permitAll()  // 인증 API는 모두 허용
+//                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()  // Swagger 허용
+//                        .requestMatchers("/actuator/health").permitAll()  // 헬스체크 허용
+//                        .anyRequest().authenticated()
+                          .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/waytoearth/config/SwaggerConfig.java
+++ b/src/main/java/com/waytoearth/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package com.waytoearth.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Way to Earth API")
+                        .description("러닝 기반 가상 여정 및 크루 시스템 API")
+                        .version("1.0.0")
+                        .contact(new Contact()
+                                .name("Way to Earth Team")
+                                .email("team@waytoearth.com")));
+    }
+}

--- a/src/main/java/com/waytoearth/config/WebConfig.java
+++ b/src/main/java/com/waytoearth/config/WebConfig.java
@@ -1,0 +1,38 @@
+package com.waytoearth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/v1/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+
+    @Bean
+    public WebClient kakaoAuthWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://kauth.kakao.com") // 토큰 발급용
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .build();
+    }
+
+    @Bean
+    public WebClient kakaoApiWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://kapi.kakao.com") // 사용자 정보 조회용 (내일 사용)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/com/waytoearth/controller/v1/AuthController.java
+++ b/src/main/java/com/waytoearth/controller/v1/AuthController.java
@@ -1,0 +1,65 @@
+package com.waytoearth.controller.v1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.waytoearth.dto.request.auth.KakaoLoginRequest;
+import com.waytoearth.dto.response.auth.KakaoTokenResponse;
+import com.waytoearth.service.auth.KakaoApiService;
+
+@Tag(name = "인증 API", description = "카카오 로그인 및 사용자 인증 관련 API")
+@RestController
+@RequestMapping("/v1/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+
+    private final KakaoApiService kakaoApiService;
+
+    @Operation(summary = "카카오 로그인 콜백", description = "카카오에서 리다이렉트된 인가 코드 처리 (브라우저 리다이렉트용)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "토큰 발급 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 인가 코드"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/kakao")
+    public ResponseEntity<KakaoTokenResponse> kakaoCallback(
+            @Parameter(description = "카카오 인가 코드", required = true, example = "abc123xyz")
+            @RequestParam("code") String code) {
+
+        log.info("[AuthController] 카카오 콜백 받음 - code: {}", code);
+
+        // 카카오에서 토큰 발급받기
+        KakaoTokenResponse response = kakaoApiService.getKakaoTokens(code);
+
+        log.info("[AuthController] 카카오 토큰 발급 완료 (GET)");
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "카카오 로그인", description = "프론트에서 인가 코드를 직접 전송하여 토큰 발급 (API 호출용)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "토큰 발급 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 인가 코드"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/kakao")
+    public ResponseEntity<KakaoTokenResponse> kakaoLogin(
+            @Parameter(description = "카카오 로그인 요청", required = true)
+            @RequestBody @Valid KakaoLoginRequest request) {
+
+        log.info("[AuthController] 카카오 로그인 요청 - authorizationCode: {}", request.getAuthorizationCode());
+
+        // 카카오에서 토큰 발급받기
+        KakaoTokenResponse response = kakaoApiService.getKakaoTokens(request.getAuthorizationCode());
+
+        log.info("[AuthController] 카카오 토큰 발급 완료 (POST)");
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/waytoearth/dto/request/auth/KakaoLoginRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/auth/KakaoLoginRequest.java
@@ -1,0 +1,18 @@
+package com.waytoearth.dto.request.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "카카오 로그인 요청")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoLoginRequest {
+
+    @Schema(description = "카카오 인가 코드", example = "abc123xyz", required = true)
+    @NotBlank(message = "인가 코드는 필수입니다")
+    private String authorizationCode;
+}

--- a/src/main/java/com/waytoearth/dto/response/auth/KakaoTokenResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/auth/KakaoTokenResponse.java
@@ -1,0 +1,32 @@
+package com.waytoearth.dto.response.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "카카오 토큰 응답")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoTokenResponse {
+
+    @Schema(description = "액세스 토큰", example = "access_token_string")
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @Schema(description = "리프레시 토큰", example = "refresh_token_string")
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @Schema(description = "토큰 타입", example = "bearer")
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @Schema(description = "만료 시간(초)", example = "7200")
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+}

--- a/src/main/java/com/waytoearth/service/auth/KakaoApiService.java
+++ b/src/main/java/com/waytoearth/service/auth/KakaoApiService.java
@@ -1,0 +1,100 @@
+package com.waytoearth.service.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import com.waytoearth.dto.response.auth.KakaoTokenResponse;
+
+import java.util.Objects;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KakaoApiService {
+
+    private final WebClient kakaoAuthWebClient;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    public KakaoTokenResponse getKakaoTokens(String authorizationCode) {
+        log.info("[KakaoApiService] 카카오 토큰 요청 시작 - code: {}", authorizationCode);
+        log.info("[KakaoApiService] client-id: {}", clientId);
+        log.info("[KakaoApiService] redirect-uri: {}", redirectUri);
+
+        try {
+            KakaoTokenDto kakaoTokenDto = kakaoAuthWebClient.post()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/oauth/token")
+                            .queryParam("grant_type", "authorization_code")
+                            .queryParam("client_id", clientId)
+                            .queryParam("redirect_uri", redirectUri)
+                            .queryParam("code", authorizationCode)
+                            .build(true))
+                    .retrieve()
+                    .bodyToMono(KakaoTokenDto.class)
+                    .block();
+
+            Objects.requireNonNull(kakaoTokenDto, "카카오 토큰 응답이 null입니다");
+
+            log.info("[KakaoApiService] 카카오 토큰 발급 성공");
+            log.info("[KakaoApiService] access_token: {}", kakaoTokenDto.getAccessToken());
+            log.info("[KakaoApiService] expires_in: {}", kakaoTokenDto.getExpiresIn());
+            log.info("[KakaoApiService] client-id: {}", clientId);
+            log.info("[KakaoApiService] redirect-uri: {}", redirectUri);
+
+            return KakaoTokenResponse.builder()
+                    .accessToken(kakaoTokenDto.getAccessToken())
+                    .refreshToken(kakaoTokenDto.getRefreshToken())
+                    .tokenType(kakaoTokenDto.getTokenType())
+                    .expiresIn(kakaoTokenDto.getExpiresIn())
+                    .build();
+
+        } catch (WebClientResponseException e) {
+            log.error("[KakaoApiService] 카카오 API 에러 - Status: {}", e.getStatusCode());
+            log.error("[KakaoApiService] 카카오 API 에러 - Response Body: {}", e.getResponseBodyAsString());
+            log.error("[KakaoApiService] 카카오 API 에러 - Headers: {}", e.getHeaders());
+            throw e;
+        } catch (Exception e) {
+            log.error("[KakaoApiService] 예상치 못한 에러", e);
+            throw e;
+        }
+    }
+
+    // 카카오 API 응답용 내부 DTO
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class KakaoTokenDto {
+        @JsonProperty("token_type")
+        private String tokenType;
+
+        @JsonProperty("access_token")
+        private String accessToken;
+
+        @JsonProperty("id_token")
+        private String idToken;
+
+        @JsonProperty("expires_in")
+        private Integer expiresIn;
+
+        @JsonProperty("refresh_token")
+        private String refreshToken;
+
+        @JsonProperty("refresh_token_expires_in")
+        private Integer refreshTokenExpiresIn;
+
+        @JsonProperty("scope")
+        private String scope;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,31 @@
 spring:
   application:
     name: waytoearth-backend
+
+# 카카오 설정 (환경변수에서 읽어옴)
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+
+# Swagger 설정
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /v3/api-docs
+
+# 로그 설정
+logging:
+  level:
+    com.waytoearth: DEBUG
+    org.springframework.web.reactive: DEBUG
+
+# 개발용 설정
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #4 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트


> 이번 PR에서 작업한 내용을 간략히 설명해주세요

-  카카오 OAuth2.0 인증 플로우 구현
- GET/POST /v1/auth/kakao 엔드포인트 추가
- 카카오 access_token, refresh_token 발급 기능
- WebClient 기반 카카오 API 연동 서비스 구현
- Swagger UI 문서화 적용 (OpenAPI 3.0)
- Spring Security 설정으로 인증 API 퍼블릭 접근 허용


### 테스트 결과 or 스크린샷 (선택)
> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요