### PR TITLE
feat: CICD 설정 및 수정 내용 반영

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy WayToEarth Backend to EC2 using Docker
+
+on:
+  push:
+    branches:
+      - login-dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name:  Checkout Source Code
+        uses: actions/checkout@v3
+
+      #  gradlew 실행 권한 부여.
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name:  Set up JDK 21 (Temurin)
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      #  RDS 접속 테스트 (EC2에서 실행).
+      - name: Test RDS connection from EC2
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            sudo apt-get update && sudo apt-get install -y mariadb-client
+            mariadb \
+              -h ${{ secrets.RDS_ENDPOINT }} \
+              -u ${{ secrets.SPRING_DATASOURCE_USERNAME }} \
+              -p${{ secrets.SPRING_DATASOURCE_PASSWORD }} \
+              -e "SELECT NOW();"
+
+      #  테스트 생략하고 빌드만 실행.
+      - name: ️ Build with Gradle (Skip Tests)
+        env:
+          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
+          SPRING_DATASOURCE_USERNAME: ${{ secrets.SPRING_DATASOURCE_USERNAME }}
+          SPRING_DATASOURCE_PASSWORD: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
+        run: ./gradlew build -x test --no-daemon
+
+      - name:  Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name:  Build and Push Docker Image
+        run: |
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/waytoearth:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/waytoearth:latest
+
+      - name:  Deploy on EC2 via SSH
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            docker pull ${{ secrets.DOCKER_USERNAME }}/waytoearth:latest
+            docker stop waytoearth || true
+            docker rm waytoearth || true
+            docker run -d \
+              -p 8080:8080 \
+              --name waytoearth \
+              --env-file /home/ubuntu/.env \
+              ${{ secrets.DOCKER_USERNAME }}/waytoearth:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:21
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,21 @@ ext {
 	querydslVersion = "5.0.0"
 }
 
+// 공통 .env 로딩 함수 정의
+def loadDotenvTo(task) {
+	def envFile = file('.env')
+	if (envFile.exists()) {
+		envFile.readLines()
+				.findAll { it && it.contains('=') && !it.startsWith('#') }
+				.each {
+					def (key, value) = it.tokenize('=')
+					if (key && value) {
+						task.environment key.trim(), value.trim()
+					}
+				}
+	}
+}
+
 dependencies {
 	// QueryDSL
 	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
@@ -78,7 +93,7 @@ dependencies {
 	// Actuator (헬스체크용 - ALB/배포 환경에서 필요)
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-	//.env 로더
+	// .env 로더
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 
 	// Test
@@ -87,21 +102,15 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
-}
-
-// .env 파일 로드
 tasks.named('bootRun') {
 	doFirst {
-		def envFile = file('.env')
-		if (envFile.exists()) {
-			envFile.readLines().each {
-				def (key, value) = it.tokenize('=')
-				if (key && value) {
-					environment key, value
-				}
-			}
-		}
+		loadDotenvTo(it)
+	}
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+	doFirst {
+		loadDotenvTo(it)
 	}
 }

--- a/src/main/java/com/waytoearth/service/auth/JwtTokenProvider.java
+++ b/src/main/java/com/waytoearth/service/auth/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.waytoearth.service.auth;
 import com.waytoearth.exception.UnauthorizedException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -14,12 +15,14 @@ import java.util.Date;
 @Slf4j
 public class JwtTokenProvider {
 
+
     private final SecretKey secretKey;
     private final long jwtExpirationMs;
 
     public JwtTokenProvider(
             @Value("${jwt.secret}") String secret,
-            @Value("${jwt.expiration:86400000}") long expiration) { // 기본값 24시간
+            @Value("${jwt.expiration:86400000}") long expiration) {
+        log.info("Loaded JWT secret: {}", secret);// 기본값 24시간
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
         this.jwtExpirationMs = expiration;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,7 +32,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:
@@ -40,7 +40,7 @@ spring:
         dialect: org.hibernate.dialect.MariaDBDialect
     open-in-view: false
 
-# 기존 KakaoApiService가 사용하는 설정
+# 기존 KakaoApiService가 사용하는 설정.
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${KAKAO_REDIRECT_URI}
@@ -48,7 +48,7 @@ kakao:
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET}
-  expiration: 86400000  # 24시간
+  expiration: 86400000
 
 # 서버 설정
 server:
@@ -64,7 +64,7 @@ springdoc:
   api-docs:
     path: /v3/api-docs
 
-# 로깅 설정
+# 로깅 설정.
 logging:
   level:
     org.hibernate.SQL: DEBUG
@@ -72,9 +72,3 @@ logging:
     org.springframework.security: DEBUG
     com.waytoearth: DEBUG
     org.springframework.web.reactive: DEBUG
-
----
-spring:
-  config:
-    activate:
-      on-profile: local


### PR DESCRIPTION
## #️⃣ 연관 이슈

> 없음

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [x] 기능 추가
* [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

* **CI/CD 자동 배포 파이프라인 추가 (`.github/workflows/deploy.yml`)**

  * 현재는 `login-dev` 브랜치 푸시 시에만 CI/CD 동작
  * GitHub Actions로 자동 빌드 → Docker Hub 푸시 → EC2 배포
  * 배포 전 EC2에서 RDS 접속 테스트 단계 추가
  * 기존 컨테이너 종료 후 최신 이미지로 재실행
  * **추후 계획:** 기능 개발 브랜치(`feature/*`) 및 버그 수정 브랜치(`bugfix/*`)에도 자동 배포 적용 예정

* **Dockerfile 추가**

  * OpenJDK 21 기반 컨테이너 이미지 구성
  * 빌드된 JAR 복사 후 실행

* **공통 `.env` 로드 함수 추가 (`build.gradle`)**

  * `loadDotenvTo` 함수 생성하여 `.env` 파일 내용을 읽고 환경 변수로 주입
  * `bootRun` 및 `test` task 실행 시 `.env` 자동 적용
  * 기존 중복 `.env` 로드 코드 제거, dotenv-java 의존성 추가

* **JWT Secret 로딩 로깅 추가 (`JwtTokenProvider.java`)**

  * JWT Secret 로드 시 `log.info` 출력 추가하여 디버깅 용이성 확보
  * JWT 기본 만료시간(24시간) 설정 로직 유지

* **Hibernate DDL 설정 변경 (`application.yml`)**

  * `ddl-auto` 옵션을 `update` → `create-drop`으로 변경 (개발/테스트 환경 초기화를 위해)
  * JWT 만료시간 주석 정리 및 불필요한 profile 설정 제거

* **주석 및 코드 스타일 정리**

  * 주석 문장부호 통일 (마침표 추가)
  * 불필요한 로컬 프로필 구분 설정 제거

### 테스트 결과 or 스크린샷 (선택)

> `.env` 로드 후 환경 변수 정상 반영 및 GitHub Actions 빌드/배포 테스트 완료
>
> <img width="717" height="791" alt="image" src="https://github.com/user-attachments/assets/8a776905-5411-4374-af7b-72d767bdc435" />  

## 💬 리뷰 요구사항 (선택)

* [ ] 현재 `ddl-auto`를 `create-drop`으로 변경했는데, 배포 환경에서는 `update`로 유지할지 여부 논의 필요
* [ ] 기능별 브랜치 자동 배포 적용 시 워크플로우 수정 범위 검토 필요
* [ ] CI/CD 배포 과정에서 `.env` 파일 관리 및 보안 방식 검토 필요