### PR TITLE
[feat] 날씨 조회 API 구현

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/WeatherController.java
+++ b/src/main/java/com/waytoearth/controller/v1/WeatherController.java
@@ -1,6 +1,6 @@
 package com.waytoearth.controller.v1;
 
-import com.waytoearth.dto.weather.WeatherCurrentResponse;
+import com.waytoearth.dto.response.weather.WeatherCurrentResponse;
 import com.waytoearth.service.weather.WeatherService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/waytoearth/controller/v1/WeatherController.java
+++ b/src/main/java/com/waytoearth/controller/v1/WeatherController.java
@@ -1,0 +1,31 @@
+package com.waytoearth.controller.v1;
+
+import com.waytoearth.dto.weather.WeatherCurrentResponse;
+import com.waytoearth.service.weather.WeatherService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Weather", description = "날씨 조회 API")
+@RestController
+@RequestMapping("/v1/weather")
+@RequiredArgsConstructor
+@Validated
+public class WeatherController {
+
+    private final WeatherService weatherService;
+
+    @Operation(summary = "현재 날씨 조회", description = "좌표(lat, lon) 기반 현재 날씨를 반환합니다.")
+    @GetMapping("/current")
+    public ResponseEntity<WeatherCurrentResponse> getCurrent(
+            @RequestParam @Min(-90) @Max(90) double lat,
+            @RequestParam @Min(-180) @Max(180) double lon
+    ) {
+        return ResponseEntity.ok(weatherService.getCurrent(lat, lon));
+    }
+}

--- a/src/main/java/com/waytoearth/dto/response/weather/WeatherCurrentResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/weather/WeatherCurrentResponse.java
@@ -1,0 +1,45 @@
+package com.waytoearth.dto.response.weather;
+
+import com.waytoearth.entity.enums.WeatherCondition;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "현재 날씨 응답")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WeatherCurrentResponse {
+
+    @Schema(description = "날씨 컨디션", example = "CLEAR")
+    private WeatherCondition condition;
+
+    @Schema(description = "기온(°C)", example = "22.7")
+    private Double temperatureC;
+
+    @Schema(description = "습도(%)", example = "63")
+    private Integer humidity;
+
+    @Schema(description = "OpenWeather 아이콘 코드(선택)", example = "10d")
+    private String iconCode;
+
+    @Schema(description = "조회 시각")
+    private LocalDateTime fetchedAt;
+
+    @Schema(description = "날씨별 러닝 추천 메시지")
+    private String recommendation;
+
+    public static WeatherCurrentResponse ofFallback(WeatherCondition c) {
+        return WeatherCurrentResponse.builder()
+                .condition(c)
+                .temperatureC(null)
+                .humidity(null)
+                .iconCode(null)
+                .fetchedAt(LocalDateTime.now())
+                .recommendation(c.getRecommendation())
+                .build();
+    }
+}

--- a/src/main/java/com/waytoearth/dto/response/weather/WeatherCurrentResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/weather/WeatherCurrentResponse.java
@@ -17,12 +17,6 @@ public class WeatherCurrentResponse {
     @Schema(description = "날씨 컨디션", example = "CLEAR")
     private WeatherCondition condition;
 
-    @Schema(description = "기온(°C)", example = "22.7")
-    private Double temperatureC;
-
-    @Schema(description = "습도(%)", example = "63")
-    private Integer humidity;
-
     @Schema(description = "OpenWeather 아이콘 코드(선택)", example = "10d")
     private String iconCode;
 
@@ -35,8 +29,6 @@ public class WeatherCurrentResponse {
     public static WeatherCurrentResponse ofFallback(WeatherCondition c) {
         return WeatherCurrentResponse.builder()
                 .condition(c)
-                .temperatureC(null)
-                .humidity(null)
                 .iconCode(null)
                 .fetchedAt(LocalDateTime.now())
                 .recommendation(c.getRecommendation())

--- a/src/main/java/com/waytoearth/entity/enums/WeatherCondition.java
+++ b/src/main/java/com/waytoearth/entity/enums/WeatherCondition.java
@@ -57,4 +57,18 @@ public enum WeatherCondition {
                 return UNKNOWN;
         }
     }
+
+    public String getRecommendation() {
+        switch (this) {
+            case CLEAR: return "맑아요! 모자와 선크림 준비하고 가볍게 달려요.";
+            case PARTLY_CLOUDY: return "구름 조금—달리기 딱 좋아요.";
+            case CLOUDY: return "흐려도 컨디션은 굿! 가벼운 바람막이 추천.";
+            case RAINY: return "비가 와요. 방수 재킷과 미끄럼 주의!";
+            case SNOWY: return "눈길 조심! 트랙션 좋은 신발을 신어주세요.";
+            case FOGGY: return "안개—가시성 주의, 밝은 색 착용 권장.";
+            case THUNDERSTORM: return "뇌우—실내 러닝으로 대체하는 게 안전합니다.";
+            default: return "컨디션 파악 중—몸 상태에 맞춰 무리하지 마세요.";
+        }
+    }
+
 }

--- a/src/main/java/com/waytoearth/security/AuthUser.java
+++ b/src/main/java/com/waytoearth/security/AuthUser.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+//로그인된 사용자 정보를 컨트롤러 메서드에 주입하기 위한 표시
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthUser {

--- a/src/main/java/com/waytoearth/service/weather/WeatherService.java
+++ b/src/main/java/com/waytoearth/service/weather/WeatherService.java
@@ -1,0 +1,7 @@
+package com.waytoearth.service.weather;
+
+import com.waytoearth.dto.response.WeatherCurrentResponse;
+
+public interface WeatherService {
+    WeatherCurrentResponse getCurrent(double lat, double lon);
+}

--- a/src/main/java/com/waytoearth/service/weather/WeatherService.java
+++ b/src/main/java/com/waytoearth/service/weather/WeatherService.java
@@ -1,6 +1,6 @@
 package com.waytoearth.service.weather;
 
-import com.waytoearth.dto.response.WeatherCurrentResponse;
+import com.waytoearth.dto.response.weather.WeatherCurrentResponse;
 
 public interface WeatherService {
     WeatherCurrentResponse getCurrent(double lat, double lon);

--- a/src/main/java/com/waytoearth/service/weather/WeatherServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/weather/WeatherServiceImpl.java
@@ -41,16 +41,12 @@ public class WeatherServiceImpl implements WeatherService {
 
             // OpenWeather main: "Clear", "Clouds", "Rain", "Snow", "Drizzle", "Thunderstorm", "Mist", ...
             String main = root.path("weather").get(0).path("main").asText("");
-            double temp = root.path("main").path("temp").asDouble(Double.NaN);
-            int humidity = root.path("main").path("humidity").asInt(-1);
             String icon = root.path("weather").get(0).path("icon").asText(""); // e.g. "10d"
 
             WeatherCondition condition = WeatherCondition.fromOpenWeatherMain(main);
 
             return WeatherCurrentResponse.builder()
                     .condition(condition)
-                    .temperatureC(temp)
-                    .humidity(humidity)
                     .iconCode(icon) // 프론트가 자체 아이콘 쓰면 무시해도 OK
                     .fetchedAt(LocalDateTime.now())
                     .recommendation(condition.getRecommendation()) // 아래 DTO 참고

--- a/src/main/java/com/waytoearth/service/weather/WeatherServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/weather/WeatherServiceImpl.java
@@ -1,0 +1,66 @@
+package com.waytoearth.service.weather;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.waytoearth.dto.response.weather.WeatherCurrentResponse;
+import com.waytoearth.entity.enums.WeatherCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class WeatherServiceImpl implements WeatherService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${weather.openweather.api-key:}")
+    private String apiKey;
+
+    @Override
+    public WeatherCurrentResponse getCurrent(double lat, double lon) {
+        // API 키가 없으면 기본값 반환 (요구사항)
+        if (apiKey == null || apiKey.isBlank()) {
+            return WeatherCurrentResponse.ofFallback(WeatherCondition.UNKNOWN);
+        }
+
+        String url = String.format(
+                "https://api.openweathermap.org/data/2.5/weather?lat=%f&lon=%f&appid=%s&units=metric",
+                lat, lon, apiKey
+        );
+
+        try {
+            ResponseEntity<String> res = restTemplate.getForEntity(url, String.class);
+            JsonNode root = objectMapper.readTree(res.getBody());
+
+            // OpenWeather main: "Clear", "Clouds", "Rain", "Snow", "Drizzle", "Thunderstorm", "Mist", ...
+            String main = root.path("weather").get(0).path("main").asText("");
+            double temp = root.path("main").path("temp").asDouble(Double.NaN);
+            int humidity = root.path("main").path("humidity").asInt(-1);
+            String icon = root.path("weather").get(0).path("icon").asText(""); // e.g. "10d"
+
+            WeatherCondition condition = WeatherCondition.fromOpenWeatherMain(main);
+
+            return WeatherCurrentResponse.builder()
+                    .condition(condition)
+                    .temperatureC(temp)
+                    .humidity(humidity)
+                    .iconCode(icon) // 프론트가 자체 아이콘 쓰면 무시해도 OK
+                    .fetchedAt(LocalDateTime.now())
+                    .recommendation(condition.getRecommendation()) // 아래 DTO 참고
+                    .build();
+
+        } catch (RestClientException | NullPointerException e) {
+            // 외부 호출 실패 시 안전한 기본값
+            return WeatherCurrentResponse.ofFallback(WeatherCondition.UNKNOWN);
+        } catch (Exception e) {
+            return WeatherCurrentResponse.ofFallback(WeatherCondition.UNKNOWN);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,6 +64,11 @@ springdoc:
   api-docs:
     path: /v3/api-docs
 
+weather:
+  openweather:
+    api-key: ${OPENWEATHER_API_KEY:}  # 없으면 빈값 -> Fallback 응답
+
+
 # 로깅 설정.
 logging:
   level:


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #12 


---

## 🛠 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 📄 작업 내용 요약
- `GET /v1/weather/current` 엔드포인트 구현
- OpenWeatherMap API 연동
- `WeatherCurrentResponse` DTO 정의 (condition, iconCode, fetchedAt, recommendation)
- `WeatherCondition` Enum 매핑 및 추천 문구 로직 추가
- API Key 미설정 시 `UNKNOWN` 상태로 Fallback 처리
- 좌표 유효성 검증(@Min, @Max) 적용
- Swagger 문서에 날씨 API 명세 추가

---

## 💬 리뷰 요구사항 (선택)
- 현재는 온도/습도를 제외한 경량 응답 구조로 구현했는데, 추후 확장 시 필요한 필드를 추가할지 검토 필요
- API Key 보관/로딩 방식에 대한 보안 점검 필요