### PR TITLE
[feat] 러닝 API 기능 개선 및 테스트 환경 구축

### DIFF
--- a/src/main/java/com/waytoearth/config/backendtest/PostmanTestDataConfig.java
+++ b/src/main/java/com/waytoearth/config/backendtest/PostmanTestDataConfig.java
@@ -17,16 +17,41 @@ public class PostmanTestDataConfig {
 
     @Bean
     CommandLineRunner initTestUser(UserRepository userRepository) {
-        return args -> userRepository.findByKakaoId(1234L)
-                .orElseGet(() -> userRepository.save(
+        return args -> {
+            //  MockAuthFilter에서 사용하는 userId=1에 맞춰 사용자 생성
+            if (!userRepository.existsById(1L)) {
+                userRepository.save(
                         User.builder()
                                 .kakaoId(1234L)
-                                .nickname("postman")
+                                .nickname("postman_user")
                                 .residence("Seoul")
                                 .ageGroup(AgeGroup.TWENTIES)
                                 .gender(Gender.MALE)
-                                .weeklyGoalDistance(new BigDecimal(10.0))
+                                .weeklyGoalDistance(new BigDecimal("10.0"))
+                                .isOnboardingCompleted(true)
                                 .build()
-                ));
+                );
+                System.out.println(" Mock 사용자 생성 완료: userId=1");
+            }
+
+            //  추가 테스트 사용자들도 생성
+            for (long i = 2; i <= 5; i++) {
+                if (!userRepository.existsById(i)) {
+                    userRepository.save(
+                            User.builder()
+                                    .kakaoId(1000L + i)
+                                    .nickname("test_user_" + i)
+                                    .residence("Seoul")
+                                    .ageGroup(AgeGroup.TWENTIES)
+                                    .gender(Gender.MALE)
+                                    .weeklyGoalDistance(new BigDecimal("5.0"))
+                                    .isOnboardingCompleted(true)
+                                    .build()
+                    );
+                }
+            }
+
+            System.out.println(" 모든 테스트 사용자 준비 완료");
+        };
     }
 }

--- a/src/main/java/com/waytoearth/controller/v1/RunningController.java
+++ b/src/main/java/com/waytoearth/controller/v1/RunningController.java
@@ -28,29 +28,29 @@ public class RunningController {
 
     @Operation(summary = "러닝 중 주기 업데이트")
     @PostMapping("/update")
-    public ResponseEntity<Void> update(
+    public ResponseEntity<RunningUpdateResponse> update(
             @AuthUser AuthenticatedUser user,
             @RequestBody RunningUpdateRequest request) {
         runningService.updateRunning(user, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(new RunningUpdateResponse(true));
     }
 
     @Operation(summary = "러닝 일시정지")
     @PostMapping("/pause")
-    public ResponseEntity<Void> pause(
+    public ResponseEntity<RunningPauseResumeResponse> pause(
             @AuthUser AuthenticatedUser user,
-            @RequestBody RunningPauseResumeRequest request) { // ✅ 공용 DTO
+            @RequestBody RunningPauseResumeRequest request) {
         runningService.pauseRunning(user, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(new RunningPauseResumeResponse(true, "PAUSED"));
     }
 
     @Operation(summary = "러닝 재개")
     @PostMapping("/resume")
-    public ResponseEntity<Void> resume(
+    public ResponseEntity<RunningPauseResumeResponse> resume(
             @AuthUser AuthenticatedUser user,
-            @RequestBody RunningPauseResumeRequest request) { // ✅ 공용 DTO
+            @RequestBody RunningPauseResumeRequest request) {
         runningService.resumeRunning(user, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(new RunningPauseResumeResponse(true, "RUNNING"));
     }
 
     @Operation(summary = "러닝 완료")

--- a/src/main/java/com/waytoearth/controller/v1/RunningController.java
+++ b/src/main/java/com/waytoearth/controller/v1/RunningController.java
@@ -1,24 +1,16 @@
 package com.waytoearth.controller.v1;
 
 
-import com.waytoearth.dto.request.running.RunningCompleteRequest;
-import com.waytoearth.dto.request.running.RunningPauseResumeRequest;
-import com.waytoearth.dto.request.running.RunningStartRequest;
-import com.waytoearth.dto.request.running.RunningUpdateRequest;
+import com.waytoearth.dto.request.running.*;
 import com.waytoearth.dto.response.running.*;
 import com.waytoearth.service.running.RunningService;
 import com.waytoearth.security.AuthUser;
 import com.waytoearth.security.AuthenticatedUser;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
-@Tag(name = "Running", description = "러닝 세션 API")
 @RestController
 @RequestMapping("/v1/running")
 @RequiredArgsConstructor
@@ -26,62 +18,64 @@ public class RunningController {
 
     private final RunningService runningService;
 
-    @Operation(summary = "러닝 시작", description = "세션 생성 및 sessionId 발급")
-    @ApiResponse(responseCode = "200", description = "성공")
+    @Operation(summary = "러닝 시작")
     @PostMapping("/start")
     public ResponseEntity<RunningStartResponse> start(
             @AuthUser AuthenticatedUser user,
-            @RequestBody RunningStartRequest request
-    ) {
+            @RequestBody RunningStartRequest request) {
         return ResponseEntity.ok(runningService.startRunning(user, request));
     }
 
-    @Operation(summary = "러닝 주기 업데이트", description = "거리/시간/페이스/칼로리 + 현재 좌표 1개 저장")
-    @ApiResponse(responseCode = "200", description = "성공")
+    @Operation(summary = "러닝 중 주기 업데이트")
     @PostMapping("/update")
-    public ResponseEntity<RunningUpdateResponse> update(
+    public ResponseEntity<Void> update(
             @AuthUser AuthenticatedUser user,
-            @RequestBody RunningUpdateRequest request
-    ) {
-        return ResponseEntity.ok(runningService.updateRunning(user, request));
+            @RequestBody RunningUpdateRequest request) {
+        runningService.updateRunning(user, request);
+        return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "러닝 일시정지", description = "상태를 PAUSED로 전환")
-    @ApiResponse(responseCode = "200", description = "성공")
+    @Operation(summary = "러닝 일시정지")
     @PostMapping("/pause")
-    public ResponseEntity<RunningPauseResumeResponse> pause(
+    public ResponseEntity<Void> pause(
             @AuthUser AuthenticatedUser user,
-            @RequestBody RunningPauseResumeRequest request
-    ) {
-        return ResponseEntity.ok(runningService.pauseRunning(user, request));
+            @RequestBody RunningPauseResumeRequest request) { // ✅ 공용 DTO
+        runningService.pauseRunning(user, request);
+        return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "러닝 재개", description = "상태를 RUNNING으로 전환")
-    @ApiResponse(responseCode = "200", description = "성공")
+    @Operation(summary = "러닝 재개")
     @PostMapping("/resume")
-    public ResponseEntity<RunningPauseResumeResponse> resume(
+    public ResponseEntity<Void> resume(
             @AuthUser AuthenticatedUser user,
-            @RequestBody RunningPauseResumeRequest request
-    ) {
-        return ResponseEntity.ok(runningService.resumeRunning(user, request));
+            @RequestBody RunningPauseResumeRequest request) { // ✅ 공용 DTO
+        runningService.resumeRunning(user, request);
+        return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "러닝 완료", description = "최종 데이터 저장 및 완료 페이지 데이터 반환")
-    @ApiResponse(responseCode = "200", description = "성공")
+    @Operation(summary = "러닝 완료")
     @PostMapping("/complete")
     public ResponseEntity<RunningCompleteResponse> complete(
             @AuthUser AuthenticatedUser user,
-            @RequestBody RunningCompleteRequest request
-    ) {
+            @RequestBody RunningCompleteRequest request) {
         return ResponseEntity.ok(runningService.completeRunning(user, request));
     }
 
-    @Operation(summary = "러닝 기록 목록", description = "완료된 기록 목록 반환")
-    @ApiResponse(responseCode = "200", description = "성공")
-    @GetMapping("/records")
-    public ResponseEntity<List<RunningRecordSummaryResponse>> records(
-            @AuthUser AuthenticatedUser user
-    ) {
-        return ResponseEntity.ok(runningService.getRecords(user));
+    @Operation(summary = "러닝 제목 수정")
+    @PatchMapping("/{recordId}/title")
+    public ResponseEntity<Void> updateTitle(
+            @AuthUser AuthenticatedUser user,
+            @PathVariable Long recordId,
+            @RequestBody RunningTitleUpdateRequest request) {
+        runningService.updateTitle(user, recordId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "러닝 상세 조회(경로 포함)")
+    @GetMapping("/{recordId}")
+    public ResponseEntity<RunningCompleteResponse> detail(
+            @AuthUser AuthenticatedUser user,
+            @PathVariable Long recordId) {
+        return ResponseEntity.ok(runningService.getDetail(user, recordId));
     }
 }

--- a/src/main/java/com/waytoearth/dto/request/running/RunningTitleUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/running/RunningTitleUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.waytoearth.dto.request.running;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RunningTitleUpdateRequest {
+    @Schema(description = "새 제목", example = "금요일 오전 러닝")
+    private String title;
+}

--- a/src/main/java/com/waytoearth/dto/response/running/RunningCompleteResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/RunningCompleteResponse.java
@@ -1,28 +1,45 @@
 package com.waytoearth.dto.response.running;
 
-import com.waytoearth.dto.request.running.RunningCompleteRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
-@Getter
+@Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class RunningCompleteResponse {
 
-    @Schema(description = "러닝 레코드 ID", example = "456")
+    @Schema(description = "러닝 기록 ID")
     private Long runningRecordId;
 
-    @Schema(description = "총 거리(km)", example = "5.2")
+    @Schema(description = "러닝 제목 (수정 가능)")
+    private String title;
+
+    @Schema(description = "총 거리 (km)")
     private double totalDistanceKm;
 
-    @Schema(description = "평균 페이스(mm:ss)", example = "05:47")
+    @Schema(description = "평균 페이스 (MM:SS)")
     private String averagePace;
 
-    @Schema(description = "칼로리", example = "350")
+    @Schema(description = "칼로리 소모량")
     private Integer calories;
 
-    @Schema(description = "경로 포인트 목록")
-    private List<RunningCompleteRequest.RoutePoint> routePoints;
+    @Schema(description = "시작 시각 (ISO 8601 문자열)")
+    private String startedAt;
+
+    @Schema(description = "완료 시각 (ISO 8601 문자열)")
+    private String endedAt;
+
+    @Schema(description = "러닝 경로 좌표 목록")
+    private List<RoutePoint> routePoints;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RoutePoint {
+        private Double latitude;
+        private Double longitude;
+        private Integer sequence;
+    }
 }

--- a/src/main/java/com/waytoearth/entity/RunningRecord.java
+++ b/src/main/java/com/waytoearth/entity/RunningRecord.java
@@ -26,8 +26,7 @@ import java.util.List;
 @Builder
 public class RunningRecord {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     /** 러닝 소유 사용자 */
@@ -53,6 +52,10 @@ public class RunningRecord {
     @Column(name = "virtual_course_id")
     private Long virtualCourseId;
 
+    @Column(length = 100)
+    private String title;
+
+    /** 러닝 상태*/
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
     private RunningStatus status;

--- a/src/main/java/com/waytoearth/repository/RunningRecordRepository.java
+++ b/src/main/java/com/waytoearth/repository/RunningRecordRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.EntityGraph;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -64,6 +65,10 @@ public interface RunningRecordRepository extends JpaRepository<RunningRecord, Lo
            """)
     BigDecimal sumCompletedDistanceByUser(@Param("user") User user);
 
-    // 사용자 완료 기록 최신순
+    // 사용자 완료 기록 최신순 (기록 탭 하단 카드)
     List<RunningRecord> findAllByUserIdAndIsCompletedTrueOrderByStartedAtDesc(Long userId);
+
+    //  상세 조회 시 경로(routes)까지 즉시 로드 (완료 페이지 재표시용)
+    @EntityGraph(attributePaths = "routes")
+    Optional<RunningRecord> findWithRoutesById(Long id);
 }

--- a/src/main/java/com/waytoearth/repository/RunningRecordRepository.java
+++ b/src/main/java/com/waytoearth/repository/RunningRecordRepository.java
@@ -65,10 +65,10 @@ public interface RunningRecordRepository extends JpaRepository<RunningRecord, Lo
            """)
     BigDecimal sumCompletedDistanceByUser(@Param("user") User user);
 
-    // 사용자 완료 기록 최신순 (기록 탭 하단 카드)
+    // 사용자 완료 기록 최신순 (기록 탭 카드)
     List<RunningRecord> findAllByUserIdAndIsCompletedTrueOrderByStartedAtDesc(Long userId);
 
-    //  상세 조회 시 경로(routes)까지 즉시 로드 (완료 페이지 재표시용)
+    //  상세 조회 시 경로(routes) 즉시 로드
     @EntityGraph(attributePaths = "routes")
     Optional<RunningRecord> findWithRoutesById(Long id);
 }

--- a/src/main/java/com/waytoearth/security/mock/MockAuthFilter.java
+++ b/src/main/java/com/waytoearth/security/mock/MockAuthFilter.java
@@ -45,7 +45,7 @@ public class MockAuthFilter extends OncePerRequestFilter {
                     .map(Long::valueOf)
                     .orElse(1L);
 
-            // ✅ AuthenticatedUser는 userId 하나만 받음
+            //  AuthenticatedUser는 userId 하나만 받음
             AuthenticatedUser principal = new AuthenticatedUser(userId);
 
             UsernamePasswordAuthenticationToken auth =

--- a/src/main/java/com/waytoearth/service/running/RunningService.java
+++ b/src/main/java/com/waytoearth/service/running/RunningService.java
@@ -1,19 +1,27 @@
 package com.waytoearth.service.running;
 
-import com.waytoearth.dto.request.running.RunningCompleteRequest;
-import com.waytoearth.dto.request.running.RunningPauseResumeRequest;
-import com.waytoearth.dto.request.running.RunningStartRequest;
-import com.waytoearth.dto.request.running.RunningUpdateRequest;
+import com.waytoearth.dto.request.running.*;
 import com.waytoearth.dto.response.running.*;
 import com.waytoearth.security.AuthenticatedUser;
 
 import java.util.List;
 
 public interface RunningService {
+
     RunningStartResponse startRunning(AuthenticatedUser user, RunningStartRequest request);
-    RunningUpdateResponse updateRunning(AuthenticatedUser user, RunningUpdateRequest request);
-    RunningPauseResumeResponse pauseRunning(AuthenticatedUser user, RunningPauseResumeRequest request);
-    RunningPauseResumeResponse resumeRunning(AuthenticatedUser user, RunningPauseResumeRequest request);
+
+    void updateRunning(AuthenticatedUser user, RunningUpdateRequest request);
+
+    //  공용 DTO로 통일
+    void pauseRunning(AuthenticatedUser user, RunningPauseResumeRequest request);
+
+    void resumeRunning(AuthenticatedUser user, RunningPauseResumeRequest request);
+
     RunningCompleteResponse completeRunning(AuthenticatedUser user, RunningCompleteRequest request);
-    List<RunningRecordSummaryResponse> getRecords(AuthenticatedUser user);
+
+    // 제목 수정
+    void updateTitle(AuthenticatedUser user, Long recordId, RunningTitleUpdateRequest request);
+
+    // 완료 페이지 재조회(경로 포함)
+    RunningCompleteResponse getDetail(AuthenticatedUser user, Long recordId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: waytoearth-backend
+    name: postman
 
   config:
     import: optional:dotenv:.env
@@ -55,15 +55,15 @@ server:
   address: 0.0.0.0
   port: 8080  # 기본 포트는 그대로
 
-# Profile별 포트 설정
-#---
-#spring:
-#  config:
-#    activate:
-#      on-profile: postman
-#
-#server:
-#  port: 9090  # ✅ postman 프로필일 때만 9090 포트 사용
+ #Profile별 포트 설정
+---
+spring:
+  config:
+    activate:
+      on-profile: postman
+
+server:
+  port: 9090  # ✅ postman 프로필일 때만 9090 포트 사용
 
 # Swagger 설정
 springdoc:

--- a/src/test/java/com/waytoearth/testcontroller/PostmanProfileSmokeTest.java
+++ b/src/test/java/com/waytoearth/testcontroller/PostmanProfileSmokeTest.java
@@ -15,8 +15,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -26,12 +24,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * postman 프로파일에서 MockAuthFilter가 자동 인증을 주입한다는 가정 하에,
- * 러닝 시작/완료 + 날씨(current) 엔드포인트를 스모크 테스트합니다.
- *
- * 경로:
- *  - RunningController:   /v1/running/start, /v1/running/complete
- *  - WeatherController:   /v1/weather/current?lat=..&lon=..
+ * postman 프로파일에서 MockAuthFilter가 자동 인증을 주입한다는 가정 하에
+ * 러닝 시작/완료 + 날씨(current) + 일시정지/재개 엔드포인트를 스모크 테스트합니다.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -39,29 +33,31 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class PostmanProfileSmokeTest {
 
     private static final String PATH_RUNNING_START    = "/v1/running/start";
+    private static final String PATH_RUNNING_UPDATE   = "/v1/running/update";
+    private static final String PATH_RUNNING_PAUSE    = "/v1/running/pause";
+    private static final String PATH_RUNNING_RESUME   = "/v1/running/resume";
     private static final String PATH_RUNNING_COMPLETE = "/v1/running/complete";
     private static final String PATH_WEATHER_CURRENT  = "/v1/weather/current";
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
 
-    // ✅ 메인 코드는 건드리지 않고, 테스트에서만 JWT 필터를 목으로 대체
-    @org.springframework.test.context.bean.override.mockito.MockitoBean
+    @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Test
-    @DisplayName("러닝: start → sessionId 파싱 → complete 200")
-    void running_flow_ok() throws Exception {
-        // 1) 러닝 시작: sessionId를 포함해서 전송
+    @DisplayName("러닝: start → pause → resume → complete 200")
+    void running_full_flow_ok() throws Exception {
+        // 1) 러닝 시작
         String sessionId = java.util.UUID.randomUUID().toString();
         String startBody = String.format("""
-    {
-      "sessionId": "%s",
-      "runningType": "SINGLE",
-      "virtualCourseId": null,
-      "weatherCondition": "맑음"
-    }
-    """, sessionId);
+        {
+          "sessionId": "%s",
+          "runningType": "SINGLE",
+          "virtualCourseId": null,
+          "weatherCondition": "맑음"
+        }
+        """, sessionId);
 
         MvcResult startRes = mockMvc.perform(
                         post(PATH_RUNNING_START)
@@ -72,28 +68,44 @@ class PostmanProfileSmokeTest {
                 .andExpect(status().isOk())
                 .andReturn();
 
-        // 2) sessionId 확인 (이미 알고 있지만 응답에서도 확인)
+        // 응답에서 sessionId 확인
         String startJson = startRes.getResponse().getContentAsString();
-        System.out.println("=== Start Response: " + startJson + " ==="); // 디버깅용
-
         JsonNode root = objectMapper.readTree(startJson);
         String responseSessionId = textOrEmpty(root, "sessionId");
         if (responseSessionId.isEmpty()) {
             responseSessionId = textOrEmpty(root.path("data"), "sessionId");
         }
-
-        // 응답에서 받은 sessionId가 있으면 사용, 없으면 보낸 것 사용
         String finalSessionId = responseSessionId.isEmpty() ? sessionId : responseSessionId;
-        Assertions.assertFalse(finalSessionId.isEmpty(), "sessionId를 확인할 수 없습니다. 보낸 sessionId: " + sessionId);
+        Assertions.assertFalse(finalSessionId.isEmpty(), "sessionId를 확인할 수 없습니다.");
 
-        // 3) 러닝 완료: 올바른 필드명 사용
+        // 2) 러닝 일시정지
+        String pauseBody = String.format("{\"sessionId\":\"%s\"}", finalSessionId);
+        mockMvc.perform(
+                        post(PATH_RUNNING_PAUSE)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(pauseBody)
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        // 3) 러닝 재개
+        String resumeBody = String.format("{\"sessionId\":\"%s\"}", finalSessionId);
+        mockMvc.perform(
+                        post(PATH_RUNNING_RESUME)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(resumeBody)
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        // 4) 러닝 완료
         Map<String, Object> complete = Map.of(
                 "sessionId", finalSessionId,
-                "distanceMeters", 5200,           // ✅ 올바른 필드명
-                "durationSeconds", 1800,          // ✅ 올바른 필드명
-                "averagePaceSeconds", 347,        // ✅ 올바른 필드명 (숫자)
+                "distanceMeters", 5200,
+                "durationSeconds", 1800,
+                "averagePaceSeconds", 347,
                 "calories", 350,
-                "routePoints", List.of(           // ✅ 올바른 필드명
+                "routePoints", List.of(
                         Map.of(
                                 "latitude", 37.5665,
                                 "longitude", 126.9780,
@@ -102,13 +114,20 @@ class PostmanProfileSmokeTest {
                 )
         );
 
-        mockMvc.perform(
+        MvcResult completeRes = mockMvc.perform(
                         post(PATH_RUNNING_COMPLETE)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(complete))
                 )
                 .andDo(print())
-                .andExpect(status().isOk());  // ✅ andExpected -> andExpect 오타 수정
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // 완료 응답 확인
+        String completeJson = completeRes.getResponse().getContentAsString();
+        JsonNode completeRoot = objectMapper.readTree(completeJson);
+        Long recordId = completeRoot.path("runningRecordId").asLong();
+        Assertions.assertTrue(recordId > 0, "러닝 완료 recordId가 유효하지 않습니다.");
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #8 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[x] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트


> 이번 PR에서 작업한 내용을 간략히 설명해주세요

러닝 API 기능 추가

- 실시간 러닝 업데이트: 러닝 중 거리/시간/경로 실시간 갱신 (POST /v1/running/update)
- 일시정지/재개 기능: 러닝 세션 제어 (POST /v1/running/pause, POST /v1/running/resume)
- 제목 수정 기능: 완료된 러닝 기록 제목 수정 (PATCH /v1/running/{recordId}/title)
- 상세 조회 기능: 경로 포함 러닝 기록 상세 조회 (GET /v1/running/{recordId})

시스템 개선

- 엔티티 필드 추가: RunningRecord에 title 필드 추가
- 서비스 시그니처 통일: 모든 러닝 서비스 메서드에서 AuthenticatedUser 파라미터 사용
- DTO 구조화: 새로운 요청/응답 DTO 추가 및 기존 DTO 개선

테스트 환경 구축

- Profile 기반 테스트: postman 프로필로 독립적인 테스트 환경 구성
- Mock 인증 시스템: JWT 우회하는 Mock 인증 필터 구현
- 자동 테스트 데이터: 테스트용 사용자 자동 생성 (userId: 1~5)
- Postman Collection: 전체 러닝 플로우 테스트 가능한 API 컬렉션 제공

인프라 개선

- 포트 분리: 메인(8080) / 테스트(9090) 포트 분리로 충돌 방지
- 보안 설정 분리: Profile별 독립적인 Spring Security 설정
- 데이터베이스 스키마: 새로운 필드 및 인덱스 추가