### PR TITLE
피드, 내정보, 프로필 구현 및 엠블럼 로직 1차 구현

### DIFF
--- a/src/main/java/com/waytoearth/config/AwsS3Config.java
+++ b/src/main/java/com/waytoearth/config/AwsS3Config.java
@@ -1,0 +1,21 @@
+// com/waytoearth/config/AwsS3Config.java
+package com.waytoearth.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+    @Bean
+    public S3Presigner s3Presigner(@Value("${cloud.aws.region}") String region) {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/com/waytoearth/controller/v1/AuthController.java
+++ b/src/main/java/com/waytoearth/controller/v1/AuthController.java
@@ -7,6 +7,7 @@ import com.waytoearth.dto.response.auth.OnboardingResponse;
 import com.waytoearth.security.AuthUser;
 import com.waytoearth.security.AuthenticatedUser;
 import com.waytoearth.service.auth.AuthService;
+import com.waytoearth.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -19,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @Tag(name = "인증 API", description = "카카오 로그인 및 사용자 인증 관련 API")
 @RestController
 @RequestMapping("/v1/auth")
@@ -27,6 +30,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final UserService userService; // ✅ 닉네임 중복 확인용
 
     @Operation(summary = "카카오 로그인", description = "카카오 Authorization Code로 로그인 처리")
     @ApiResponses({
@@ -39,8 +43,7 @@ public class AuthController {
             @Parameter(description = "카카오 로그인 요청", required = true)
             @RequestBody @Valid KakaoLoginRequest request) {
 
-        log.info("[AuthController] 카카오 로그인 요청 - authorizationCode: {}",
-                request.getCode());
+        log.info("[AuthController] 카카오 로그인 요청 - authorizationCode: {}", request.getCode());
 
         LoginResponse response = authService.loginWithKakaoCode(request.getCode());
 
@@ -74,5 +77,35 @@ public class AuthController {
 
         log.info("[AuthController] 온보딩 완료 - userId: {}", response.getUserId());
         return ResponseEntity.ok(response);
+    }
+
+    // ===============================
+    // ✅ 닉네임 중복 확인 (추가)
+    // ===============================
+    @Operation(
+            summary = "닉네임 중복 확인",
+            description = "닉네임 사용 가능 여부를 확인합니다. (무인증)",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "확인 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                    @ApiResponse(responseCode = "500", description = "서버 오류")
+            }
+    )
+    @GetMapping("/check-nickname")
+    public ResponseEntity<Map<String, Object>> checkNickname(
+            @Parameter(description = "중복 확인할 닉네임", required = true)
+            @RequestParam String nickname) {
+
+        log.info("[AuthController] 닉네임 중복 확인 요청 - nickname: {}", nickname);
+
+        boolean available = !userService.existsByNickname(nickname);
+
+        Map<String, Object> body = Map.of(
+                "available", available,
+                "message", available ? "사용 가능한 닉네임입니다." : "이미 사용 중인 닉네임입니다."
+        );
+
+        log.info("[AuthController] 닉네임 중복 확인 결과 - nickname: {}, available: {}", nickname, available);
+        return ResponseEntity.ok(body);
     }
 }

--- a/src/main/java/com/waytoearth/controller/v1/EmblemController.java
+++ b/src/main/java/com/waytoearth/controller/v1/EmblemController.java
@@ -1,0 +1,74 @@
+// com/waytoearth/controller/v1/EmblemController.java
+package com.waytoearth.controller.v1;
+
+import com.waytoearth.dto.response.emblem.EmblemAwardResult;
+import com.waytoearth.dto.response.emblem.EmblemCatalogItem;
+import com.waytoearth.dto.response.emblem.EmblemDetailResponse;
+import com.waytoearth.dto.response.emblem.EmblemSummaryResponse;
+import com.waytoearth.security.AuthUser;
+import com.waytoearth.security.AuthenticatedUser;
+import com.waytoearth.service.emblem.EmblemService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Emblem API", description = "엠블럼 조회/지급 API")
+@RestController
+@RequestMapping("/v1/emblems")
+@RequiredArgsConstructor
+public class EmblemController {
+
+    private final EmblemService emblemService;
+
+    /* ===== 조회 ===== */
+
+    @Operation(summary = "내 엠블럼 요약")
+    @GetMapping("/me/summary")
+    public ResponseEntity<EmblemSummaryResponse> summary(@AuthUser AuthenticatedUser me) {
+        return ResponseEntity.ok(emblemService.summary(me.getUserId()));
+    }
+
+    @Operation(summary = "엠블럼 카탈로그(필터/커서 지원)")
+    @GetMapping("/catalog")
+    public ResponseEntity<List<EmblemCatalogItem>> catalog(
+            @AuthUser AuthenticatedUser me,
+            @RequestParam(defaultValue = "ALL") String filter,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) Long cursor
+    ) {
+        return ResponseEntity.ok(emblemService.catalog(me.getUserId(), filter, size, cursor));
+    }
+
+    @Operation(summary = "엠블럼 상세")
+    @GetMapping("/{id}")
+    public ResponseEntity<EmblemDetailResponse> detail(@AuthUser AuthenticatedUser me,
+                                                       @PathVariable Long id) {
+        return ResponseEntity.ok(emblemService.detail(me.getUserId(), id));
+    }
+
+    /* ===== 지급 ===== */
+
+    @Operation(summary = "엠블럼 지급 시도(단건)", description = "조건 충족 시 해당 엠블럼을 지급합니다.")
+    @PostMapping("/{id}/award")
+    public ResponseEntity<EmblemAwardResult> awardOne(@AuthUser AuthenticatedUser me,
+                                                      @PathVariable Long id) {
+        boolean ok = emblemService.awardIfEligible(me.getUserId(), id);
+        return ResponseEntity.ok(
+                EmblemAwardResult.builder()
+                        .awardedCount(ok ? 1 : 0)
+                        .awardedEmblemIds(ok ? List.of(id) : List.of())
+                        .build()
+        );
+    }
+
+    @Operation(summary = "엠블럼 일괄 스캔 지급", description = "scope: DISTANCE | ALL (기본 DISTANCE)")
+    @PostMapping("/award/scan")
+    public ResponseEntity<EmblemAwardResult> scanAndAward(@AuthUser AuthenticatedUser me,
+                                                          @RequestParam(defaultValue = "DISTANCE") String scope) {
+        return ResponseEntity.ok(emblemService.scanAndAward(me.getUserId(), scope));
+    }
+}

--- a/src/main/java/com/waytoearth/controller/v1/FeedController.java
+++ b/src/main/java/com/waytoearth/controller/v1/FeedController.java
@@ -1,0 +1,85 @@
+package com.waytoearth.controller.v1;
+
+import com.waytoearth.dto.request.feed.FeedCreateRequest;
+import com.waytoearth.dto.response.feed.FeedResponse;
+import com.waytoearth.dto.response.feed.FeedLikeResponse;
+import com.waytoearth.security.AuthUser;
+import com.waytoearth.security.AuthenticatedUser;
+import com.waytoearth.service.feed.FeedService;
+import com.waytoearth.service.file.FileService;
+import com.waytoearth.dto.request.file.PresignRequest;
+import com.waytoearth.dto.response.file.PresignResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Feed API", description = "피드 작성, 조회, 좋아요, 삭제, 이미지 업로드 API")
+@RestController
+@RequestMapping("/v1/feeds")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final FeedService feedService;
+    private final FileService fileService;
+
+    @Operation(summary = "피드 작성")
+    @PostMapping
+    public ResponseEntity<FeedResponse> createFeed(
+            @AuthUser AuthenticatedUser user,
+            @RequestBody FeedCreateRequest req
+    ) {
+        return ResponseEntity.ok(feedService.createFeed(user, req));
+    }
+
+    @Operation(summary = "피드 목록 조회 (무한 스크롤)")
+    @GetMapping
+    public ResponseEntity<List<FeedResponse>> getFeeds(
+            @AuthUser AuthenticatedUser user,
+            @RequestParam(defaultValue = "0") int offset,
+            @RequestParam(defaultValue = "8") int limit
+    ) {
+        return ResponseEntity.ok(feedService.getFeeds(user, offset, limit));
+    }
+
+    @Operation(summary = "피드 단건 조회 (좋아요 여부 포함)")
+    @GetMapping("/{feedId}")
+    public ResponseEntity<FeedResponse> getFeed(
+            @AuthUser AuthenticatedUser user,
+            @PathVariable Long feedId
+    ) {
+        return ResponseEntity.ok(feedService.getFeed(user, feedId));
+    }
+
+    @Operation(summary = "피드 삭제")
+    @DeleteMapping("/{feedId}")
+    public ResponseEntity<?> deleteFeed(
+            @AuthUser AuthenticatedUser user,
+            @PathVariable Long feedId
+    ) {
+        feedService.deleteFeed(user, feedId);
+        return ResponseEntity.ok().body("{\"message\":\"피드가 삭제되었습니다.\"}");
+    }
+
+    @Operation(summary = "피드 좋아요 (토글)")
+    @PostMapping("/{feedId}/like")
+    public ResponseEntity<FeedLikeResponse> toggleLike(
+            @AuthUser AuthenticatedUser user,
+            @PathVariable Long feedId
+    ) {
+        return ResponseEntity.ok(feedService.toggleLike(user, feedId));
+    }
+
+    @Operation(summary = "피드 이미지 업로드 Presigned URL 발급")
+    @PostMapping("/{feedId}/image/presign")
+    public ResponseEntity<PresignResponse> presignImageUpload(
+            @AuthUser AuthenticatedUser user,
+            @PathVariable Long feedId,
+            @RequestBody PresignRequest req
+    ) {
+        return ResponseEntity.ok(fileService.presignProfile(user.getUserId(), req));
+    }
+}

--- a/src/main/java/com/waytoearth/controller/v1/FileController.java
+++ b/src/main/java/com/waytoearth/controller/v1/FileController.java
@@ -1,0 +1,41 @@
+// com/waytoearth/controller/v1/FileController.java
+package com.waytoearth.controller.v1;
+
+import com.waytoearth.dto.request.file.PresignRequest;
+import com.waytoearth.dto.response.file.PresignResponse;
+import com.waytoearth.security.AuthenticatedUser;
+import com.waytoearth.security.AuthUser;
+import com.waytoearth.service.file.FileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "파일 업로드", description = "S3 Presigned URL 기반 파일 업로드 API")
+@RestController
+@RequestMapping("/v1/files")
+@RequiredArgsConstructor
+public class FileController {
+
+    private final FileService fileService;
+
+    @Operation(summary = "프로필 이미지 업로드 Presigned URL 발급", description = "사용자가 프로필 이미지를 업로드할 수 있도록 S3 Presigned URL을 발급한다.")
+    @PostMapping("/presign/profile")
+    public ResponseEntity<PresignResponse> presignProfile(
+            @AuthUser AuthenticatedUser me,
+            @Valid @RequestBody PresignRequest request
+    ) {
+        return ResponseEntity.ok(fileService.presignProfile(me.getUserId(), request));
+    }
+
+    @Operation(summary = "피드 이미지 업로드 Presigned URL 발급", description = "사용자가 피드 공유 시 이미지를 업로드할 수 있도록 S3 Presigned URL을 발급한다.")
+    @PostMapping("/presign/feed")
+    public ResponseEntity<PresignResponse> presignFeed(
+            @AuthUser AuthenticatedUser me,
+            @Valid @RequestBody PresignRequest request
+    ) {
+        return ResponseEntity.ok(fileService.presignFeed(me.getUserId(), request));
+    }
+}

--- a/src/main/java/com/waytoearth/controller/v1/RunningController.java
+++ b/src/main/java/com/waytoearth/controller/v1/RunningController.java
@@ -1,0 +1,81 @@
+package com.waytoearth.controller.v1;
+
+
+import com.waytoearth.dto.request.running.*;
+import com.waytoearth.dto.response.running.*;
+import com.waytoearth.service.running.RunningService;
+import com.waytoearth.security.AuthUser;
+import com.waytoearth.security.AuthenticatedUser;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/running")
+@RequiredArgsConstructor
+public class RunningController {
+
+    private final RunningService runningService;
+
+    @Operation(summary = "러닝 시작")
+    @PostMapping("/start")
+    public ResponseEntity<RunningStartResponse> start(
+            @AuthUser AuthenticatedUser user,
+            @RequestBody RunningStartRequest request) {
+        return ResponseEntity.ok(runningService.startRunning(user, request));
+    }
+
+    @Operation(summary = "러닝 중 주기 업데이트")
+    @PostMapping("/update")
+    public ResponseEntity<RunningUpdateResponse> update(
+            @AuthUser AuthenticatedUser user,
+            @RequestBody RunningUpdateRequest request) {
+        runningService.updateRunning(user, request);
+        return ResponseEntity.ok(new RunningUpdateResponse(true));
+    }
+
+    @Operation(summary = "러닝 일시정지")
+    @PostMapping("/pause")
+    public ResponseEntity<RunningPauseResumeResponse> pause(
+            @AuthUser AuthenticatedUser user,
+            @RequestBody RunningPauseResumeRequest request) {
+        runningService.pauseRunning(user, request);
+        return ResponseEntity.ok(new RunningPauseResumeResponse(true, "PAUSED"));
+    }
+
+    @Operation(summary = "러닝 재개")
+    @PostMapping("/resume")
+    public ResponseEntity<RunningPauseResumeResponse> resume(
+            @AuthUser AuthenticatedUser user,
+            @RequestBody RunningPauseResumeRequest request) {
+        runningService.resumeRunning(user, request);
+        return ResponseEntity.ok(new RunningPauseResumeResponse(true, "RUNNING"));
+    }
+
+    @Operation(summary = "러닝 완료")
+    @PostMapping("/complete")
+    public ResponseEntity<RunningCompleteResponse> complete(
+            @AuthUser AuthenticatedUser user,
+            @RequestBody RunningCompleteRequest request) {
+        return ResponseEntity.ok(runningService.completeRunning(user, request));
+    }
+
+    @Operation(summary = "러닝 제목 수정")
+    @PatchMapping("/{recordId}/title")
+    public ResponseEntity<Void> updateTitle(
+            @AuthUser AuthenticatedUser user,
+            @PathVariable Long recordId,
+            @RequestBody RunningTitleUpdateRequest request) {
+        runningService.updateTitle(user, recordId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "러닝 상세 조회(경로 포함)")
+    @GetMapping("/{recordId}")
+    public ResponseEntity<RunningCompleteResponse> detail(
+            @AuthUser AuthenticatedUser user,
+            @PathVariable Long recordId) {
+        return ResponseEntity.ok(runningService.getDetail(user, recordId));
+    }
+}

--- a/src/main/java/com/waytoearth/controller/v1/UserController.java
+++ b/src/main/java/com/waytoearth/controller/v1/UserController.java
@@ -1,14 +1,18 @@
 package com.waytoearth.controller.v1;
 
+import com.waytoearth.dto.request.user.UserUpdateRequest;
+import com.waytoearth.dto.response.user.UserInfoResponse;
+import com.waytoearth.dto.response.user.UserSummaryResponse;
+import com.waytoearth.security.AuthenticatedUser;
+import com.waytoearth.security.AuthUser;
 import com.waytoearth.service.user.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,6 +24,10 @@ public class UserController {
 
     private final UserService userService;
 
+    /**
+     * 닉네임 중복 확인
+     * (기존 엔드포인트 유지: /v1/users/check-nickname)
+     */
     @GetMapping("/check-nickname")
     public ResponseEntity<Map<String, Object>> checkNicknameDuplicate(@RequestParam String nickname) {
         log.info("[NicknameCheck] 닉네임 중복 확인 요청 - nickname: {}", nickname);
@@ -30,8 +38,45 @@ public class UserController {
         response.put("message", isDuplicate ? "이미 사용 중인 닉네임입니다." : "사용 가능한 닉네임입니다.");
 
         log.info("[NicknameCheck] 결과 - nickname: {}, isDuplicate: {}", nickname, isDuplicate);
-
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 내 정보 전체 조회
+     * GET /v1/users/me
+     */
+    @GetMapping("/me")
+    public ResponseEntity<UserInfoResponse> me(@AuthUser AuthenticatedUser me) {
+        log.info("[Users:Me] 내 정보 조회 - userId: {}", me.getUserId());
+        UserInfoResponse body = userService.getMe(me.getUserId());
+        return ResponseEntity.ok(body);
+    }
+
+    /**
+     * 내 정보 요약(총거리/횟수/엠블럼/완성도)
+     * GET /v1/users/me/summary
+     */
+    @GetMapping("/me/summary")
+    public ResponseEntity<UserSummaryResponse> summary(@AuthUser AuthenticatedUser me) {
+        log.info("[Users:Summary] 요약 조회 - userId: {}", me.getUserId());
+        UserSummaryResponse body = userService.getSummary(me.getUserId());
+        return ResponseEntity.ok(body);
+    }
+
+    /**
+     * 프로필 수정
+     * PUT /v1/users/me
+     * Body: nickname, profile_image_url, residence, weekly_goal_distance(선택/부분 수정)
+     */
+    @PutMapping("/me")
+    public ResponseEntity<Map<String, Object>> updateProfile(@AuthUser AuthenticatedUser me,
+                                                             @Valid @RequestBody UserUpdateRequest request) {
+        log.info("[Users:Update] 프로필 수정 요청 - userId: {}, payload: {}", me.getUserId(), request);
+        userService.updateProfile(me.getUserId(), request);
+
+        Map<String, Object> res = new HashMap<>();
+        res.put("message", "프로필이 수정되었습니다.");
+        res.put("updated_at", Instant.now().toString());
+        return ResponseEntity.ok(res);
+    }
 }

--- a/src/main/java/com/waytoearth/controller/v1/WeatherController.java
+++ b/src/main/java/com/waytoearth/controller/v1/WeatherController.java
@@ -1,0 +1,31 @@
+package com.waytoearth.controller.v1;
+
+import com.waytoearth.dto.response.weather.WeatherCurrentResponse;
+import com.waytoearth.service.weather.WeatherService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Weather", description = "날씨 조회 API")
+@RestController
+@RequestMapping("/v1/weather")
+@RequiredArgsConstructor
+@Validated
+public class WeatherController {
+
+    private final WeatherService weatherService;
+
+    @Operation(summary = "현재 날씨 조회", description = "좌표(lat, lon) 기반 현재 날씨를 반환합니다.")
+    @GetMapping("/current")
+    public ResponseEntity<WeatherCurrentResponse> getCurrent(
+            @RequestParam @Min(-90) @Max(90) double lat,
+            @RequestParam @Min(-180) @Max(180) double lon
+    ) {
+        return ResponseEntity.ok(weatherService.getCurrent(lat, lon));
+    }
+}

--- a/src/main/java/com/waytoearth/dto/request/feed/FeedCreateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/feed/FeedCreateRequest.java
@@ -1,0 +1,17 @@
+package com.waytoearth.dto.request.feed;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+public class FeedCreateRequest {
+
+    @Schema(description = "연결된 러닝 기록 ID", example = "456")
+    private Long runningRecordId;
+
+    @Schema(description = "피드 텍스트", example = "오늘 5km 달렸어요! 🏃‍♂️")
+    private String content;
+
+    @Schema(description = "이미지 URL (S3 업로드 후 경로)", example = "https://example.com/running_photo.jpg")
+    private String imageUrl;
+}

--- a/src/main/java/com/waytoearth/dto/request/file/PresignRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/file/PresignRequest.java
@@ -1,0 +1,23 @@
+// com/waytoearth/dto/request/file/PresignRequest.java
+package com.waytoearth.dto.request.file;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PresignRequest {
+
+    @NotBlank
+    private String contentType;
+
+    @Positive
+    private long size;
+
+    public PresignRequest(String contentType, long size) {
+        this.contentType = contentType;
+        this.size = size;
+    }
+}

--- a/src/main/java/com/waytoearth/dto/request/running/RunningCompleteRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/running/RunningCompleteRequest.java
@@ -1,0 +1,57 @@
+package com.waytoearth.dto.request.running;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.util.List;
+
+@Schema(description = "러닝 완료 요청")
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RunningCompleteRequest {
+
+    @Schema(description = "러닝 세션 ID", example = "b6b2b8b5-2d8d-4e8f-9a8e-7e6c5d4f3a21", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "sessionId는 필수입니다.")
+    private String sessionId;
+
+    @Schema(description = "총 이동 거리(미터)", example = "5200", requiredMode = Schema.RequiredMode.REQUIRED)
+    @PositiveOrZero(message = "distanceMeters는 0 이상이어야 합니다.")
+    private Integer distanceMeters;
+
+    @Schema(description = "총 소요 시간(초)", example = "1800", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Positive(message = "durationSeconds는 0보다 커야 합니다.")
+    private Integer durationSeconds;
+
+    @Schema(description = "평균 페이스(초/킬로미터). 서버에서 재계산해도 됨.", example = "347")
+    @Positive(message = "averagePaceSeconds는 0보다 커야 합니다.")
+    private Integer averagePaceSeconds;
+
+    @Schema(description = "칼로리(kcal). 서버에서 계산/보정 가능", example = "350")
+    @PositiveOrZero(message = "calories는 0 이상이어야 합니다.")
+    private Integer calories;
+
+    @Schema(description = "경로 좌표 리스트(선택). sequence 오름차순으로 정렬해 주세요.")
+    @Valid
+    private List<RoutePoint> routePoints;
+
+    @Getter @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "경로 좌표 한 점")
+    public static class RoutePoint {
+        @Schema(description = "위도", example = "37.5665", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull private Double latitude;
+
+        @Schema(description = "경도", example = "126.9780", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull private Double longitude;
+
+        @Schema(description = "경로 순서(0부터 시작 권장)", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Min(value = 0, message = "sequence는 0 이상이어야 합니다.")
+        private Integer sequence;
+    }
+}

--- a/src/main/java/com/waytoearth/dto/request/running/RunningPauseResumeRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/running/RunningPauseResumeRequest.java
@@ -1,0 +1,11 @@
+package com.waytoearth.dto.request.running;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class RunningPauseResumeRequest {
+    @Schema(description = "세션 ID", example = "abc123")
+    private String sessionId;
+}

--- a/src/main/java/com/waytoearth/dto/request/running/RunningStartRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/running/RunningStartRequest.java
@@ -1,0 +1,27 @@
+package com.waytoearth.dto.request.running;
+
+import com.waytoearth.entity.enums.RunningType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Schema(description = "러닝 시작 요청")
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RunningStartRequest {
+
+    @Schema(description = "러닝 세션 ID (클라이언트 또는 서버 생성)", example = "b6b2b8b5-2d8d-4e8f-9a8e-7e6c5d4f3a21", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "sessionId는 필수입니다.")
+    private String sessionId;
+
+    @Schema(description = "러닝 타입", example = "SINGLE", requiredMode = Schema.RequiredMode.REQUIRED,
+            allowableValues = {"SINGLE", "VIRTUAL"})
+    @NotNull(message = "runningType은 필수입니다.")
+    private RunningType runningType;
+
+    @Schema(description = "가상 러닝 코스 ID (가상 러닝일 경우에만 사용)", example = "123")
+    private Long virtualCourseId;
+}

--- a/src/main/java/com/waytoearth/dto/request/running/RunningTitleUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/running/RunningTitleUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.waytoearth.dto.request.running;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RunningTitleUpdateRequest {
+    @Schema(description = "새 제목", example = "금요일 오전 러닝")
+    private String title;
+}

--- a/src/main/java/com/waytoearth/dto/request/running/RunningUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/running/RunningUpdateRequest.java
@@ -1,0 +1,37 @@
+package com.waytoearth.dto.request.running;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter @Setter
+public class RunningUpdateRequest {
+    @Schema(description = "세션 ID", example = "abc123")
+    private String sessionId;
+
+    @Schema(description = "누적 이동 거리(미터)", example = "1500")
+    private double distanceMeters;
+
+    @Schema(description = "누적 운동 시간(초)", example = "420")
+    private int durationSeconds;
+
+    @Schema(description = "평균 페이스(초/킬로)", example = "280")
+    private int averagePaceSeconds;
+
+    @Schema(description = "소모 칼로리", example = "110")
+    private int calories;
+
+    @Schema(description = "현재 좌표 포인트")
+    private PointDto currentPoint;
+
+    @Getter @Setter
+    public static class PointDto {
+        @Schema(example = "37.5665")
+        private double latitude;
+        @Schema(example = "126.9780")
+        private double longitude;
+        @Schema(description = "경로 순번(0부터)", example = "15")
+        private int sequence;
+    }
+}

--- a/src/main/java/com/waytoearth/dto/request/user/UserUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/user/UserUpdateRequest.java
@@ -1,0 +1,36 @@
+// com/waytoearth/dto/request/user/UserUpdateRequest.java
+package com.waytoearth.dto.request.user;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserUpdateRequest {
+
+        @Size(min = 2, max = 20)
+        private String nickname;
+
+        @JsonProperty("profile_image_url")
+        @JsonAlias({"profileImageUrl"})
+        @Pattern(regexp = "^https?://.*$", message = "유효한 URL이어야 합니다.")
+        private String profileImageUrl;
+
+        @Size(min = 2, max = 100)
+        private String residence;
+
+        @JsonProperty("weekly_goal_distance")
+        @JsonAlias({"weeklyGoalDistance"})
+        @DecimalMin(value = "0.01")
+        @DecimalMax(value = "999.99")
+        private BigDecimal weeklyGoalDistance;
+}

--- a/src/main/java/com/waytoearth/dto/response/emblem/EmblemAwardResult.java
+++ b/src/main/java/com/waytoearth/dto/response/emblem/EmblemAwardResult.java
@@ -1,0 +1,32 @@
+package com.waytoearth.dto.response.emblem;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@Getter
+@Builder
+@Schema(name = "EmblemAwardResult", description = "엠블럼 지급 결과")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class EmblemAwardResult {
+
+    @Schema(description = "지급된 엠블럼 개수", example = "2")
+    private int awardedCount;
+
+    @Schema(description = "지급된 엠블럼 ID 목록", example = "[1,5]")
+    private List<Long> awardedEmblemIds;
+
+    public EmblemAwardResult() { }
+
+    public EmblemAwardResult(int awardedCount, List<Long> awardedEmblemIds) {
+        this.awardedCount = awardedCount;
+        this.awardedEmblemIds = awardedEmblemIds;
+    }
+
+}

--- a/src/main/java/com/waytoearth/dto/response/emblem/EmblemCatalogItem.java
+++ b/src/main/java/com/waytoearth/dto/response/emblem/EmblemCatalogItem.java
@@ -1,0 +1,53 @@
+package com.waytoearth.dto.response.emblem;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Setter
+@Getter
+@Builder
+@Schema(name = "EmblemCatalogItem", description = "엠블럼 카탈로그 항목")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class EmblemCatalogItem {
+
+    @Schema(description = "엠블럼 ID", example = "12")
+    private Long emblemId;
+
+    @Schema(description = "이름", example = "첫 러닝 완주")
+    private String name;
+
+    @Schema(description = "설명", example = "첫 러닝을 완주하면 지급됩니다.")
+    private String description;
+
+    @Schema(description = "이미지 URL", example = "https://cdn.example.com/emblems/12.png")
+    private String imageUrl;
+
+    @Schema(description = "희귀도", example = "COMMON")
+    private String rarity;
+
+    @Schema(description = "보유 여부", example = "true")
+    private boolean owned;
+
+    @Schema(description = "획득 시각(보유 시)", example = "2025-01-26T10:00:00Z")
+    private Instant earnedAt;
+
+    public EmblemCatalogItem() { }
+
+    public EmblemCatalogItem(Long emblemId, String name, String description, String imageUrl,
+                             String rarity, boolean owned, Instant earnedAt) {
+        this.emblemId = emblemId;
+        this.name = name;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.rarity = rarity;
+        this.owned = owned;
+        this.earnedAt = earnedAt;
+    }
+
+}

--- a/src/main/java/com/waytoearth/dto/response/emblem/EmblemDetailResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/emblem/EmblemDetailResponse.java
@@ -1,0 +1,63 @@
+package com.waytoearth.dto.response.emblem;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Setter
+@Getter
+@Builder
+@Schema(name = "EmblemDetailResponse", description = "엠블럼 상세 정보")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class EmblemDetailResponse {
+
+    @Schema(description = "엠블럼 ID", example = "12")
+    private Long emblemId;
+
+    @Schema(description = "이름", example = "첫 러닝 완주")
+    private String name;
+
+    @Schema(description = "설명", example = "첫 러닝을 완주하면 지급됩니다.")
+    private String description;
+
+    @Schema(description = "이미지 URL", example = "https://cdn.example.com/emblems/12.png")
+    private String imageUrl;
+
+    @Schema(description = "희귀도", example = "COMMON")
+    private String rarity;
+
+    @Schema(description = "지급 조건 타입", example = "DISTANCE")
+    private String conditionType;
+
+    @Schema(description = "지급 조건 값", example = "100.00")
+    private BigDecimal conditionValue;
+
+    @Schema(description = "보유 여부", example = "true")
+    private boolean owned;
+
+    @Schema(description = "획득 시각(보유 시)", example = "2025-01-26T10:00:00Z")
+    private Instant earnedAt;
+
+    public EmblemDetailResponse() { }
+
+    public EmblemDetailResponse(Long emblemId, String name, String description, String imageUrl,
+                                String rarity, String conditionType, BigDecimal conditionValue,
+                                boolean owned, Instant earnedAt) {
+        this.emblemId = emblemId;
+        this.name = name;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.rarity = rarity;
+        this.conditionType = conditionType;
+        this.conditionValue = conditionValue;
+        this.owned = owned;
+        this.earnedAt = earnedAt;
+    }
+
+}

--- a/src/main/java/com/waytoearth/dto/response/emblem/EmblemSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/emblem/EmblemSummaryResponse.java
@@ -1,0 +1,34 @@
+package com.waytoearth.dto.response.emblem;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+@Schema(name = "EmblemSummaryResponse", description = "내 엠블럼 요약")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class EmblemSummaryResponse {
+
+    @Schema(description = "보유 개수", example = "8")
+    private int owned;
+
+    @Schema(description = "전체 개수", example = "15")
+    private int total;
+
+    @Schema(description = "완성도(0~1)", example = "0.53")
+    private double completionRate;
+
+    public EmblemSummaryResponse() { }
+
+    public EmblemSummaryResponse(int owned, int total, double completionRate) {
+        this.owned = owned;
+        this.total = total;
+        this.completionRate = completionRate;
+    }
+
+}

--- a/src/main/java/com/waytoearth/dto/response/feed/FeedCreateResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/feed/FeedCreateResponse.java
@@ -1,0 +1,18 @@
+package com.waytoearth.dto.response.feed;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class FeedCreateResponse {
+
+    @Schema(description = "생성된 피드 ID", example = "123")
+    private Long feedId;
+
+    @Schema(description = "작성일시", example = "2025-01-26T11:05:00")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/waytoearth/dto/response/feed/FeedLikeResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/feed/FeedLikeResponse.java
@@ -1,0 +1,10 @@
+package com.waytoearth.dto.response.feed;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "좋아요 응답 DTO")
+public record FeedLikeResponse(
+        @Schema(description = "피드 ID") Long feedId,
+        @Schema(description = "현재 좋아요 수") int likeCount,
+        @Schema(description = "좋아요 여부") boolean liked
+) {}

--- a/src/main/java/com/waytoearth/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/feed/FeedResponse.java
@@ -1,0 +1,80 @@
+package com.waytoearth.dto.response.feed;
+
+import com.waytoearth.entity.Feed;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Schema(description = "피드 응답 DTO")
+@Builder
+public record FeedResponse(
+        @Schema(description = "피드 ID", example = "101")
+        Long id,
+
+        @Schema(description = "피드 본문(한줄 글쓰기)", example = "오늘 5km 달림!")
+        String content,
+
+        @Schema(description = "업로드된 이미지 URL (S3)", example = "https://s3.../feed123.jpg")
+        String imageUrl,
+
+        @Schema(description = "좋아요 개수", example = "12")
+        int likeCount,
+
+        @Schema(description = "현재 로그인한 사용자가 좋아요 눌렀는지 여부", example = "true")
+        boolean liked,   // 👈 새로 추가됨
+
+        @Schema(description = "작성 시간", example = "2025-08-18T02:45:00Z")
+        Instant createdAt,
+
+        @Schema(description = "작성자 ID", example = "7")
+        Long userId,
+
+        @Schema(description = "작성자 닉네임", example = "평러너")
+        String nickname,
+
+        @Schema(description = "작성자 프로필 이미지 URL", example = "https://s3.../profile7.png")
+        String profileImageUrl,
+
+        @Schema(description = "연동된 러닝 거리(km)", example = "5.32")
+        Double distance,
+
+        @Schema(description = "연동된 러닝 시간(초)", example = "1800")
+        Integer duration,
+
+        @Schema(description = "평균 페이스 (분:초/km)", example = "05:45")
+        String averagePace,
+
+        @Schema(description = "소모 칼로리", example = "320")
+        Integer calories
+) {
+    public static FeedResponse from(Feed feed, boolean liked) {
+        return FeedResponse.builder()
+                .id(feed.getId())
+                .content(feed.getContent())
+                .imageUrl(feed.getImageUrl())
+                .likeCount(feed.getLikeCount())
+                .liked(liked)   // 👈 좋아요 여부 반영
+                .createdAt(feed.getCreatedAt())
+                .userId(feed.getUser().getId())
+                .nickname(feed.getUser().getNickname())
+                .profileImageUrl(feed.getUser().getProfileImageUrl())
+                .distance(feed.getRunningRecord() != null ?
+                        (feed.getRunningRecord().getDistance() != null ?
+                                feed.getRunningRecord().getDistance().doubleValue() : null) : null)
+                .duration(feed.getRunningRecord() != null ?
+                        feed.getRunningRecord().getDuration() : null)
+                .averagePace(feed.getRunningRecord() != null ?
+                        formatPace(feed.getRunningRecord().getAveragePaceSeconds()) : null)
+                .calories(feed.getRunningRecord() != null ?
+                        feed.getRunningRecord().getCalories() : null)
+                .build();
+    }
+
+    private static String formatPace(Integer paceSeconds) {
+        if (paceSeconds == null) return null;
+        int minutes = paceSeconds / 60;
+        int seconds = paceSeconds % 60;
+        return String.format("%d:%02d", minutes, seconds);
+    }
+}

--- a/src/main/java/com/waytoearth/dto/response/feed/MessageResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/feed/MessageResponse.java
@@ -1,0 +1,12 @@
+package com.waytoearth.dto.response.feed;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MessageResponse {
+    @Schema(description = "응답 메시지", example = "피드가 삭제되었습니다.")
+    private String message;
+}

--- a/src/main/java/com/waytoearth/dto/response/feed/PageResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/feed/PageResponse.java
@@ -1,0 +1,18 @@
+package com.waytoearth.dto.response.feed;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PageResponse<T> {
+
+    @Schema(description = "조회된 피드 목록")
+    private List<T> feeds;
+
+    @Schema(description = "다음 페이지 여부", example = "true")
+    private boolean hasMore;
+}

--- a/src/main/java/com/waytoearth/dto/response/file/PresignResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/file/PresignResponse.java
@@ -1,0 +1,36 @@
+package com.waytoearth.dto.response.file;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Schema(name = "PresignResponse", description = "S3 Presigned URL 응답")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PresignResponse {
+
+    @Schema(description = "업로드용 Presigned URL")
+    private String uploadUrl;
+
+    @Schema(description = "업로드 후 접근 가능한 공개 URL")
+    private String publicUrl;
+
+    @Schema(description = "S3 오브젝트 키", example = "profiles/12345.png")
+    private String key;
+
+    @Schema(description = "만료 시간(초)", example = "300")
+    private int expiresIn;
+
+    public PresignResponse() { }
+
+    public PresignResponse(String uploadUrl, String publicUrl, String key, int expiresIn) {
+        this.uploadUrl = uploadUrl;
+        this.publicUrl = publicUrl;
+        this.key = key;
+        this.expiresIn = expiresIn;
+    }
+
+}

--- a/src/main/java/com/waytoearth/dto/response/running/RunningCompleteResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/RunningCompleteResponse.java
@@ -1,0 +1,45 @@
+package com.waytoearth.dto.response.running;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RunningCompleteResponse {
+
+    @Schema(description = "러닝 기록 ID")
+    private Long runningRecordId;
+
+    @Schema(description = "러닝 제목 (수정 가능)")
+    private String title;
+
+    @Schema(description = "총 거리 (km)")
+    private double totalDistanceKm;
+
+    @Schema(description = "평균 페이스 (MM:SS)")
+    private String averagePace;
+
+    @Schema(description = "칼로리 소모량")
+    private Integer calories;
+
+    @Schema(description = "시작 시각 (ISO 8601 문자열)")
+    private String startedAt;
+
+    @Schema(description = "완료 시각 (ISO 8601 문자열)")
+    private String endedAt;
+
+    @Schema(description = "러닝 경로 좌표 목록")
+    private List<RoutePoint> routePoints;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RoutePoint {
+        private Double latitude;
+        private Double longitude;
+        private Integer sequence;
+    }
+}

--- a/src/main/java/com/waytoearth/dto/response/running/RunningPauseResumeResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/RunningPauseResumeResponse.java
@@ -1,0 +1,15 @@
+package com.waytoearth.dto.response.running;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Getter
+@AllArgsConstructor
+public class RunningPauseResumeResponse {
+    @Schema(description = "처리 여부", example = "true")
+    private boolean ack;
+
+    @Schema(description = "현재 상태", example = "PAUSED")
+    private String status;
+}

--- a/src/main/java/com/waytoearth/dto/response/running/RunningRecordSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/RunningRecordSummaryResponse.java
@@ -1,0 +1,30 @@
+package com.waytoearth.dto.response.running;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RunningRecordSummaryResponse {
+    @Schema(example = "456")
+    private Long id;
+
+    @Schema(example = "금요일 오전 러닝")
+    private String title;
+
+    @Schema(description = "거리(km)", example = "5.2")
+    private double distanceKm;
+
+    @Schema(description = "운동 시간(초)", example = "1800")
+    private int durationSeconds;
+
+    @Schema(description = "평균 페이스(문자열 mm:ss)", example = "05:47")
+    private String averagePace;
+
+    @Schema(description = "칼로리", example = "350")
+    private int calories;
+
+    @Schema(description = "시작 시각(ISO-8601)", example = "2025-08-14T09:30:00")
+    private String startedAt;
+}

--- a/src/main/java/com/waytoearth/dto/response/running/RunningStartResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/RunningStartResponse.java
@@ -1,0 +1,20 @@
+package com.waytoearth.dto.response.running;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "러닝 시작 응답")
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RunningStartResponse {
+
+    @Schema(description = "러닝 세션 ID", example = "b6b2b8b5-2d8d-4e8f-9a8e-7e6c5d4f3a21")
+    private String sessionId;
+
+    @Schema(description = "러닝 시작 시각(서버 기준 ISO-8601)", example = "2025-08-10T09:30:00")
+    private LocalDateTime startedAt;
+}

--- a/src/main/java/com/waytoearth/dto/response/running/RunningUpdateResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/RunningUpdateResponse.java
@@ -1,0 +1,12 @@
+package com.waytoearth.dto.response.running;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RunningUpdateResponse {
+    @Schema(description = "저장 성공 여부", example = "true")
+    private boolean ack;
+}

--- a/src/main/java/com/waytoearth/dto/response/statistics/RunningWeeklyStatsResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/statistics/RunningWeeklyStatsResponse.java
@@ -1,0 +1,61 @@
+package com.waytoearth.dto.response.statistics;
+
+import java.util.List;
+
+public class RunningWeeklyStatsResponse {
+
+    private double totalDistance;       // 총 거리 (km)
+    private long totalDuration;         // 총 시간 (초)
+    private String averagePace;         // 평균 페이스 (mm:ss)
+    private int totalCalories;          // 총 칼로리
+    private List<DailyDistance> dailyDistances; // 요일별 거리
+
+    public RunningWeeklyStatsResponse(double totalDistance, long totalDuration,
+                                      String averagePace, int totalCalories,
+                                      List<DailyDistance> dailyDistances) {
+        this.totalDistance = totalDistance;
+        this.totalDuration = totalDuration;
+        this.averagePace = averagePace;
+        this.totalCalories = totalCalories;
+        this.dailyDistances = dailyDistances;
+    }
+
+    public double getTotalDistance() {
+        return totalDistance;
+    }
+
+    public long getTotalDuration() {
+        return totalDuration;
+    }
+
+    public String getAveragePace() {
+        return averagePace;
+    }
+
+    public int getTotalCalories() {
+        return totalCalories;
+    }
+
+    public List<DailyDistance> getDailyDistances() {
+        return dailyDistances;
+    }
+
+    // 내부 클래스: 요일별 거리
+    public static class DailyDistance {
+        private String day;       // 요일명 (예: MONDAY)
+        private double distance;  // 해당 요일 총 거리
+
+        public DailyDistance(String day, double distance) {
+            this.day = day;
+            this.distance = distance;
+        }
+
+        public String getDay() {
+            return day;
+        }
+
+        public double getDistance() {
+            return distance;
+        }
+    }
+}

--- a/src/main/java/com/waytoearth/dto/response/user/UserInfoResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/user/UserInfoResponse.java
@@ -1,0 +1,65 @@
+package com.waytoearth.dto.response.user;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Setter
+@Getter
+@Schema(name = "UserInfoResponse", description = "내 정보 상세")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UserInfoResponse {
+
+    @Schema(description = "사용자 ID", example = "12345")
+    private Long id;
+
+    @Schema(description = "닉네임", example = "홍러너")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지 URL")
+    private String profileImageUrl;
+
+    @Schema(description = "거주지", example = "서울특별시 강남구")
+    private String residence;
+
+    @Schema(description = "연령대", example = "20대")
+    private String ageGroup;
+
+    @Schema(description = "성별", example = "남성")
+    private String gender;
+
+    @Schema(description = "주간 목표 거리(km)", example = "15.5")
+    private BigDecimal weeklyGoalDistance;
+
+    @Schema(description = "총 누적 거리(km)", example = "247.8")
+    private BigDecimal totalDistance;
+
+    @Schema(description = "총 러닝 횟수", example = "45")
+    private Integer totalRunningCount;
+
+    @Schema(description = "가입 일시(UTC)", example = "2025-01-15T10:00:00Z")
+    private Instant createdAt;
+
+    public UserInfoResponse() { }
+
+    public UserInfoResponse(Long id, String nickname, String profileImageUrl, String residence,
+                            String ageGroup, String gender, BigDecimal weeklyGoalDistance,
+                            BigDecimal totalDistance, Integer totalRunningCount, Instant createdAt) {
+        this.id = id;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.residence = residence;
+        this.ageGroup = ageGroup;
+        this.gender = gender;
+        this.weeklyGoalDistance = weeklyGoalDistance;
+        this.totalDistance = totalDistance;
+        this.totalRunningCount = totalRunningCount;
+        this.createdAt = createdAt;
+    }
+
+}

--- a/src/main/java/com/waytoearth/dto/response/user/UserSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/user/UserSummaryResponse.java
@@ -1,0 +1,36 @@
+package com.waytoearth.dto.response.user;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Schema(name = "UserSummaryResponse", description = "내 정보 요약")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UserSummaryResponse {
+
+    @Schema(description = "완성도(보유 엠블럼/전체)", example = "0.53")
+    private double completionRate;
+
+    @Schema(description = "보유 엠블럼 개수", example = "8")
+    private int emblemCount;
+
+    @Schema(description = "총 누적 거리(km)", example = "247.8")
+    private double totalDistance;
+
+    @Schema(description = "총 러닝 횟수", example = "45")
+    private int totalRunningCount;
+
+    public UserSummaryResponse() { }
+
+    public UserSummaryResponse(double completionRate, int emblemCount, double totalDistance, int totalRunningCount) {
+        this.completionRate = completionRate;
+        this.emblemCount = emblemCount;
+        this.totalDistance = totalDistance;
+        this.totalRunningCount = totalRunningCount;
+    }
+
+}

--- a/src/main/java/com/waytoearth/dto/response/weather/WeatherCurrentResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/weather/WeatherCurrentResponse.java
@@ -1,0 +1,41 @@
+package com.waytoearth.dto.response.weather;
+
+import com.waytoearth.entity.enums.WeatherCondition;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "현재 날씨 응답")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WeatherCurrentResponse {
+
+    @Schema(description = "날씨 컨디션", example = "CLEAR")
+    private WeatherCondition condition;
+
+    @Schema(description = "OpenWeather 아이콘 코드(선택)", example = "10d")
+    private String iconCode;
+
+    @Schema(description = "날씨 이모지", example = "☁️")
+    private String emoji;
+
+    @Schema(description = "조회 시각")
+    private LocalDateTime fetchedAt;
+
+    @Schema(description = "날씨별 러닝 추천 메시지")
+    private String recommendation;
+
+    public static WeatherCurrentResponse ofFallback(WeatherCondition c) {
+        return WeatherCurrentResponse.builder()
+                .condition(c)
+                .emoji(c.getEmoji())
+                .iconCode(null)
+                .fetchedAt(LocalDateTime.now())
+                .recommendation(c.getRecommendation())
+                .build();
+    }
+}

--- a/src/main/java/com/waytoearth/entity/Emblem.java
+++ b/src/main/java/com/waytoearth/entity/Emblem.java
@@ -1,0 +1,54 @@
+package com.waytoearth.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Entity
+@Table(name = "emblems")
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@Schema(description = "엠블럼 정보 엔티티")
+public class Emblem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "엠블럼 ID", example = "1")
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    @Schema(description = "엠블럼 이름", example = "첫 러닝 완주")
+    private String name;
+
+    @Column(length = 500)
+    @Schema(description = "엠블럼 설명", example = "첫 러닝을 완주하면 지급됩니다.")
+    private String description;
+
+    @Column(length = 500)
+    @Schema(description = "엠블럼 이미지 URL", example = "https://cdn.example.com/emblems/1.png")
+    private String imageUrl;
+
+    @Column(length = 20)
+    @Schema(description = "희귀도", example = "COMMON")
+    private String rarity; // OPTIONAL
+
+    @Column(name = "condition_type", length = 30)
+    @Schema(description = "지급 조건 타입", example = "DISTANCE")
+    private String conditionType; // OPTIONAL (서비스에서 사용)
+
+    @Column(name = "condition_value", precision = 8, scale = 2)
+    @Schema(description = "지급 조건 값", example = "100.00")
+    private BigDecimal conditionValue; // OPTIONAL (서비스에서 사용)
+
+    @Column(nullable = false, updatable = false)
+    @Schema(description = "생성 시각")
+    private Instant createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) createdAt = Instant.now();
+    }
+}

--- a/src/main/java/com/waytoearth/entity/Feed.java
+++ b/src/main/java/com/waytoearth/entity/Feed.java
@@ -1,0 +1,47 @@
+package com.waytoearth.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "feeds")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Feed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 작성자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 연관 러닝 기록
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "running_record_id")
+    private RunningRecord runningRecord;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "like_count", nullable = false)
+    private int likeCount = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    public void onCreate() {
+        this.createdAt = Instant.now();
+    }
+}

--- a/src/main/java/com/waytoearth/entity/FeedLike.java
+++ b/src/main/java/com/waytoearth/entity/FeedLike.java
@@ -1,0 +1,32 @@
+package com.waytoearth.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder   // ✅ 추가
+@Table(name = "feed_likes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"feed_id", "user_id"})
+})
+public class FeedLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public FeedLike(Feed feed, User user) {
+        this.feed = feed;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/waytoearth/entity/RunningRecord.java
+++ b/src/main/java/com/waytoearth/entity/RunningRecord.java
@@ -1,0 +1,112 @@
+package com.waytoearth.entity;
+
+import com.waytoearth.entity.enums.RunningType;
+import com.waytoearth.entity.enums.WeatherCondition;
+import com.waytoearth.entity.enums.RunningStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(
+        name = "running_record",
+        indexes = {
+                @Index(name = "idx_running_user_completed_started", columnList = "user_id,is_completed,started_at"),
+                @Index(name = "idx_running_session", columnList = "session_id", unique = true)
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RunningRecord {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 러닝 소유 사용자 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /** 세션 ID (러닝 고유 식별) */
+    @Column(name = "session_id", nullable = false, unique = true, length = 100)
+    private String sessionId;
+
+    /** 러닝 타입 */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "running_type", nullable = false, length = 20)
+    private RunningType runningType;
+
+    /** 가상 코스 ID (가상 러닝 시 사용) */
+    @Column(name = "virtual_course_id")
+    private Long virtualCourseId;
+
+    @Column(length = 100)
+    private String title;
+
+    /** 러닝 상태*/
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private RunningStatus status;
+
+    /** 총 거리(km) */
+    @Column(name = "distance", precision = 10, scale = 2)
+    private BigDecimal distance;
+
+    /** 총 시간(초) */
+    @Column(name = "duration_seconds")
+    private Integer duration;
+
+    /** 평균 페이스(초/킬로미터) */
+    @Column(name = "average_pace_seconds")
+    private Integer averagePaceSeconds;
+
+    /** 칼로리(kcal) */
+    @Column(name = "calories")
+    private Integer calories;
+
+    /** 완료 여부 */
+    @Column(name = "is_completed", nullable = false)
+    private Boolean isCompleted;
+
+    /** 시작 시각 */
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    /** 종료 시각 */
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
+
+    /** 경로 데이터 */
+    @OneToMany(mappedBy = "runningRecord", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sequence ASC")
+    private List<RunningRoute> routes = new ArrayList<>();
+
+    /** 러닝 완료 처리 */
+    public void complete(BigDecimal distanceKm, Integer durationSeconds, Integer paceSec,
+                         Integer calories, LocalDateTime endedAt) {
+        this.distance = distanceKm;
+        this.duration = durationSeconds;
+        this.averagePaceSeconds = paceSec;
+        this.calories = calories;
+        this.endedAt = endedAt;
+        this.isCompleted = true;
+        this.status = RunningStatus.COMPLETED;
+    }
+
+    /** 경로 포인트 추가 */
+    public void addRoutePoint(Double latitude, Double longitude, Integer sequence) {
+        RunningRoute route = new RunningRoute();
+        route.setRunningRecord(this);
+        route.setLatitude(latitude);
+        route.setLongitude(longitude);
+        route.setSequence(sequence);
+        this.routes.add(route);
+    }
+}

--- a/src/main/java/com/waytoearth/entity/RunningRoute.java
+++ b/src/main/java/com/waytoearth/entity/RunningRoute.java
@@ -1,0 +1,40 @@
+package com.waytoearth.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "running_route",
+        indexes = {
+                @Index(name = "idx_route_record_seq", columnList = "running_record_id,sequence")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RunningRoute {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 소속 러닝 기록 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "running_record_id", nullable = false)
+    private RunningRecord runningRecord;
+
+    /** 위도 */
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    /** 경도 */
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
+    /** 경로 순서 */
+    @Column(name = "sequence", nullable = false)
+    private Integer sequence;
+}

--- a/src/main/java/com/waytoearth/entity/User.java
+++ b/src/main/java/com/waytoearth/entity/User.java
@@ -28,9 +28,11 @@ public class User {
     @Column(name = "kakao_id", unique = true, nullable = false)
     private Long kakaoId;
 
+    @Setter
     @Column(name = "nickname", length = 20, unique = true)
     private String nickname;
 
+    @Setter
     @Column(name = "residence", length = 100)
     private String residence;
 
@@ -42,9 +44,11 @@ public class User {
     @Column(name = "gender")
     private Gender gender;
 
+    @Setter
     @Column(name = "weekly_goal_distance", precision = 5, scale = 2)
     private BigDecimal weeklyGoalDistance;
 
+    @Setter
     @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
@@ -65,6 +69,7 @@ public class User {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Setter
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
@@ -86,4 +91,6 @@ public class User {
         this.totalDistance = this.totalDistance.add(distance);
         this.totalRunningCount++;
     }
+
+
 }

--- a/src/main/java/com/waytoearth/entity/UserEmblem.java
+++ b/src/main/java/com/waytoearth/entity/UserEmblem.java
@@ -1,0 +1,42 @@
+package com.waytoearth.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "user_emblems",
+        uniqueConstraints = @UniqueConstraint(name = "uk_user_emblem", columnNames = {"user_id", "emblem_id"})
+)
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@Schema(description = "사용자-엠블럼 수집 내역 엔티티")
+public class UserEmblem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "유저-엠블럼 관계 ID", example = "10")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Schema(description = "엠블럼을 보유한 사용자")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "emblem_id", nullable = false)
+    @Schema(description = "보유한 엠블럼")
+    private Emblem emblem;
+
+    @Column(nullable = false, updatable = false)
+    @Schema(description = "엠블럼 획득 시각")
+    private Instant acquiredAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (acquiredAt == null) acquiredAt = Instant.now();
+    }
+}

--- a/src/main/java/com/waytoearth/entity/enums/RunningStatus.java
+++ b/src/main/java/com/waytoearth/entity/enums/RunningStatus.java
@@ -1,0 +1,7 @@
+package com.waytoearth.entity.enums;
+
+public enum RunningStatus {
+    RUNNING,
+    PAUSED,
+    COMPLETED
+}

--- a/src/main/java/com/waytoearth/entity/enums/RunningType.java
+++ b/src/main/java/com/waytoearth/entity/enums/RunningType.java
@@ -1,0 +1,29 @@
+package com.waytoearth.entity.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum RunningType {
+    SINGLE("SINGLE", "싱글 러닝"),
+    VIRTUAL("VIRTUAL", "가상 러닝");
+
+    private final String code;
+    private final String description;
+
+    @JsonValue
+    public String getCode() {
+        return code;
+    }
+
+    public static RunningType fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(type -> type.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid RunningType code: " + code));
+    }
+}

--- a/src/main/java/com/waytoearth/entity/enums/WeatherCondition.java
+++ b/src/main/java/com/waytoearth/entity/enums/WeatherCondition.java
@@ -1,0 +1,66 @@
+package com.waytoearth.entity.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WeatherCondition {
+    CLEAR("맑음", "☀️"),
+    PARTLY_CLOUDY("구름조금", "⛅"),
+    CLOUDY("흐림", "☁️"),
+    RAINY("비", "🌧️"),
+    SNOWY("눈", "❄️"),
+    FOGGY("안개", "🌫️"),
+    THUNDERSTORM("천둥번개", "⛈️"),
+    UNKNOWN("알수없음", "❓");
+
+    private final String label;
+    private final String emoji;
+
+    // 응답(JSON)엔 한글로 나감
+    @JsonValue
+    public String getLabel() { return label; }
+
+    // 요청(JSON)에서도 한글만 받음
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static WeatherCondition fromJson(String value) {
+        if (value == null) return UNKNOWN;
+        for (WeatherCondition c : values()) {
+            if (c.label.equals(value)) return c;   // "맑음" 등 한글만 허용
+        }
+        return UNKNOWN; // 모르면 UNKNOWN 처리 (400 내리고 싶으면 예외 던져도 됨)
+    }
+
+    // OpenWeather 변환(내부용) - 그대로 유지
+    public static WeatherCondition fromOpenWeatherMain(String main) {
+        if (main == null) return UNKNOWN;
+        switch (main.toLowerCase()) {
+            case "clear":        return CLEAR;
+            case "clouds":       return CLOUDY;
+            case "rain":
+            case "drizzle":      return RAINY;
+            case "snow":         return SNOWY;
+            case "mist":
+            case "fog":
+            case "haze":         return FOGGY;
+            case "thunderstorm": return THUNDERSTORM;
+            default:             return UNKNOWN;
+        }
+    }
+
+    public String getRecommendation() {
+        switch (this) {
+            case CLEAR:        return "맑아요! 모자와 선크림 준비하고 가볍게 달려요.";
+            case PARTLY_CLOUDY:return "구름 조금—달리기 딱 좋아요.";
+            case CLOUDY:       return "흐려도 컨디션은 굿! 가벼운 바람막이 추천.";
+            case RAINY:        return "비가 와요. 방수 재킷과 미끄럼 주의!";
+            case SNOWY:        return "눈길 조심! 트랙션 좋은 신발을 신어주세요.";
+            case FOGGY:        return "안개—가시성 주의, 밝은 색 착용 권장.";
+            case THUNDERSTORM: return "뇌우—실내 러닝으로 대체하는 게 안전합니다.";
+            default:           return "컨디션 파악 중—몸 상태에 맞춰 무리하지 마세요.";
+        }
+    }
+}

--- a/src/main/java/com/waytoearth/repository/EmblemRepository.java
+++ b/src/main/java/com/waytoearth/repository/EmblemRepository.java
@@ -1,0 +1,16 @@
+// com/waytoearth/repository/EmblemRepository.java
+package com.waytoearth.repository;
+
+import com.waytoearth.entity.Emblem;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EmblemRepository extends JpaRepository<Emblem, Long> {
+    List<Emblem> findAllByOrderByIdDesc(Pageable pageable);
+    List<Emblem> findByIdLessThanOrderByIdDesc(Long cursor, Pageable pageable);
+
+    // 지급 스캔용: 조건 타입별 조회
+    List<Emblem> findByConditionTypeIgnoreCase(String conditionType);
+}

--- a/src/main/java/com/waytoearth/repository/FeedLikeRepository.java
+++ b/src/main/java/com/waytoearth/repository/FeedLikeRepository.java
@@ -1,0 +1,16 @@
+package com.waytoearth.repository;
+
+import com.waytoearth.entity.Feed;
+import com.waytoearth.entity.FeedLike;
+import com.waytoearth.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
+    boolean existsByFeedAndUser(Feed feed, User user);
+    Optional<FeedLike> findByFeedAndUser(Feed feed, User user);
+    int countByFeed(Feed feed);
+    void deleteByFeedAndUser(Feed feed, User user);
+
+}

--- a/src/main/java/com/waytoearth/repository/FeedRepository.java
+++ b/src/main/java/com/waytoearth/repository/FeedRepository.java
@@ -1,0 +1,11 @@
+package com.waytoearth.repository;
+
+import com.waytoearth.entity.Feed;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+    List<Feed> findAllByOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/src/main/java/com/waytoearth/repository/RunningRecordRepository.java
+++ b/src/main/java/com/waytoearth/repository/RunningRecordRepository.java
@@ -1,0 +1,74 @@
+package com.waytoearth.repository;
+
+import com.waytoearth.entity.RunningRecord;
+import com.waytoearth.entity.User;
+import com.waytoearth.entity.enums.RunningType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.EntityGraph;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RunningRecordRepository extends JpaRepository<RunningRecord, Long> {
+
+    // 진행 중 세션 존재 여부(중복 시작 방지)
+    boolean existsBySessionIdAndIsCompletedFalse(String sessionId);
+
+    // ===== 단건 조회 =====
+    Optional<RunningRecord> findBySessionId(String sessionId);
+    Optional<RunningRecord> findByIdAndUser(Long id, User user);
+
+    // 진행 중인 세션(사용자당 0~1개가 정상)
+    Optional<RunningRecord> findByUserAndIsCompletedFalse(User user);
+    boolean existsByUserAndIsCompletedFalse(User user);
+
+    // ===== 목록 조회 (완료된 기록) =====
+    // 기본 목록 - 최신순 페이징
+    Page<RunningRecord> findByUserAndIsCompletedTrueOrderByStartedAtDesc(User user, Pageable pageable);
+
+    // 타입 필터 + 최신순 페이징
+    Page<RunningRecord> findByUserAndRunningTypeAndIsCompletedTrueOrderByStartedAtDesc(
+            User user, RunningType runningType, Pageable pageable);
+
+    // 기간 필터 (비페이징, 최신/오름 정렬 각각 제공)
+    List<RunningRecord> findByUserAndIsCompletedTrueAndStartedAtBetweenOrderByStartedAtDesc(
+            User user, LocalDateTime startDate, LocalDateTime endDate);
+
+    List<RunningRecord> findByUserAndRunningTypeAndIsCompletedTrueAndStartedAtBetweenOrderByStartedAtDesc(
+            User user, RunningType runningType, LocalDateTime startDate, LocalDateTime endDate);
+
+    List<RunningRecord> findByUserAndIsCompletedTrueAndStartedAtBetweenOrderByStartedAtAsc(
+            User user, LocalDateTime startDate, LocalDateTime endDate);
+
+    // 기간 필터 + 페이징 (필요 시 사용)
+    Page<RunningRecord> findByUserAndIsCompletedTrueAndStartedAtBetweenOrderByStartedAtDesc(
+            User user, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+
+    Page<RunningRecord> findByUserAndRunningTypeAndIsCompletedTrueAndStartedAtBetweenOrderByStartedAtDesc(
+            User user, RunningType runningType, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+
+    // ===== 누적/통계 =====
+    long countByUserAndIsCompletedTrue(User user);
+
+    @Query("""
+           select coalesce(sum(r.distance), 0)
+           from RunningRecord r
+           where r.user = :user and r.isCompleted = true
+           """)
+    BigDecimal sumCompletedDistanceByUser(@Param("user") User user);
+
+    // 사용자 완료 기록 최신순 (기록 탭 카드)
+    List<RunningRecord> findAllByUserIdAndIsCompletedTrueOrderByStartedAtDesc(Long userId);
+
+    //  상세 조회 시 경로(routes) 즉시 로드
+    @EntityGraph(attributePaths = "routes")
+    Optional<RunningRecord> findWithRoutesById(Long id);
+}

--- a/src/main/java/com/waytoearth/repository/RunningRouteRepository.java
+++ b/src/main/java/com/waytoearth/repository/RunningRouteRepository.java
@@ -1,0 +1,7 @@
+package com.waytoearth.repository;
+
+import com.waytoearth.entity.RunningRoute;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RunningRouteRepository extends JpaRepository<RunningRoute, Long> {
+}

--- a/src/main/java/com/waytoearth/repository/UserEmblemRepository.java
+++ b/src/main/java/com/waytoearth/repository/UserEmblemRepository.java
@@ -1,0 +1,42 @@
+// com/waytoearth/repository/UserEmblemRepository.java
+package com.waytoearth.repository;
+
+import com.waytoearth.entity.Emblem;
+import com.waytoearth.entity.User;
+import com.waytoearth.entity.UserEmblem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserEmblemRepository extends JpaRepository<UserEmblem, Long> {
+
+    /** 사용자 보유 엠블럼 개수 */
+    @Query("select count(ue) from UserEmblem ue where ue.user.id = :userId")
+    long countByUserId(@Param("userId") Long userId);
+
+    /** 사용자 보유 엠블럼 목록 */
+    @Query("select ue from UserEmblem ue join fetch ue.emblem where ue.user.id = :userId")
+    List<UserEmblem> findByUserId(@Param("userId") Long userId);
+
+    /** 특정 엠블럼 보유 여부 (userId, emblemId) */
+    @Query("select case when count(ue) > 0 then true else false end " +
+            "from UserEmblem ue where ue.user.id = :userId and ue.emblem.id = :emblemId")
+    boolean existsByUserIdAndEmblemId(@Param("userId") Long userId, @Param("emblemId") Long emblemId);
+
+    /** 특정 엠블럼 보유 레코드 (userId, emblemId) */
+    @Query("select ue from UserEmblem ue " +
+            "where ue.user.id = :userId and ue.emblem.id = :emblemId")
+    Optional<UserEmblem> findByUserIdAndEmblemId(@Param("userId") Long userId, @Param("emblemId") Long emblemId);
+
+    /** 사용자 보유 여부 (엔티티 직접 비교) - 서비스에서 사용 */
+    boolean existsByUserAndEmblem(User user, Emblem emblem);
+
+    /** 배치 조회: 주어진 emblemIds 중 보유한 목록 */
+    @Query("select ue from UserEmblem ue " +
+            "where ue.user.id = :userId and ue.emblem.id in :emblemIds")
+    List<UserEmblem> findByUserIdAndEmblemIdIn(@Param("userId") Long userId,
+                                               @Param("emblemIds") List<Long> emblemIds);
+}

--- a/src/main/java/com/waytoearth/repository/statistics/StatisticsRepositoryCustom.java
+++ b/src/main/java/com/waytoearth/repository/statistics/StatisticsRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.waytoearth.repository.statistics;
+
+import com.waytoearth.dto.response.statistics.RunningWeeklyStatsResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+//복잡한 쿼리용
+public interface StatisticsRepositoryCustom {
+
+    WeeklyStatsDto getWeeklyStats(Long userId, LocalDateTime start, LocalDateTime end);
+
+    List<RunningWeeklyStatsResponse.DailyDistance> getDailyDistances(Long userId, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/waytoearth/repository/statistics/StatisticsRepositoryImpl.java
+++ b/src/main/java/com/waytoearth/repository/statistics/StatisticsRepositoryImpl.java
@@ -1,0 +1,81 @@
+package com.waytoearth.repository.statistics;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.waytoearth.dto.response.statistics.RunningWeeklyStatsResponse;
+import com.waytoearth.entity.QRunningRecord;
+import jakarta.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QRunningRecord record = QRunningRecord.runningRecord;
+
+    public StatisticsRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public WeeklyStatsDto getWeeklyStats(Long userId, LocalDateTime start, LocalDateTime end) {
+        return queryFactory
+                .select(Projections.constructor(
+                        WeeklyStatsDto.class,
+                        record.distance.sum(),
+                        record.duration.sum(),
+                        record.averagePaceSeconds.avg(), // ← 엔티티 필드명에 맞춤
+                        record.calories.sum()
+                ))
+                .from(record)
+                .where(
+                        record.user.id.eq(userId),
+                        record.isCompleted.isTrue(),
+                        record.startedAt.between(start, end)
+                )
+                .fetchOne();
+    }
+
+    @Override
+    public List<RunningWeeklyStatsResponse.DailyDistance> getDailyDistances(
+            Long userId, LocalDateTime start, LocalDateTime end) {
+
+        var dayExp  = record.startedAt.dayOfWeek();            // IntegerExpression
+        var distExp = record.distance.sum().doubleValue();     // NumberExpression<Double>
+
+        return queryFactory
+                .select(dayExp, distExp)
+                .from(record)
+                .where(
+                        record.user.id.eq(userId),
+                        record.isCompleted.isTrue(),
+                        record.startedAt.between(start, end)
+                )
+                .groupBy(dayExp)
+                .orderBy(dayExp.asc())
+                .fetch()
+                .stream()
+                .map(tuple -> new RunningWeeklyStatsResponse.DailyDistance(
+                        mapDayOfWeek(tuple.get(dayExp)),
+                        safeDouble(tuple.get(distExp))     // 이미 Double이라 경고 없음
+                ))
+                .toList();
+    }
+
+    private static double safeDouble(Double v) { return v == null ? 0.0 : v; }
+
+    private static String mapDayOfWeek(Integer v) {
+        if (v == null) return "UNKNOWN";
+        return switch (v) {
+            case 1 -> "SUNDAY";
+            case 2 -> "MONDAY";
+            case 3 -> "TUESDAY";
+            case 4 -> "WEDNESDAY";
+            case 5 -> "THURSDAY";
+            case 6 -> "FRIDAY";
+            case 7 -> "SATURDAY";
+            default -> "UNKNOWN";
+        };
+    }
+}

--- a/src/main/java/com/waytoearth/repository/statistics/WeeklyStatsDto.java
+++ b/src/main/java/com/waytoearth/repository/statistics/WeeklyStatsDto.java
@@ -1,0 +1,21 @@
+package com.waytoearth.repository.statistics;
+
+public class WeeklyStatsDto {
+    private final Double totalDistance;
+    private final Long totalDuration;
+    private final Double averagePaceSeconds; // 평균 페이스 초 단위
+    private final Integer totalCalories;
+
+    public WeeklyStatsDto(Double totalDistance, Long totalDuration,
+                          Double averagePaceSeconds, Integer totalCalories) {
+        this.totalDistance = totalDistance == null ? 0.0 : totalDistance;
+        this.totalDuration = totalDuration == null ? 0L : totalDuration;
+        this.averagePaceSeconds = averagePaceSeconds == null ? 0.0 : averagePaceSeconds;
+        this.totalCalories = totalCalories == null ? 0 : totalCalories;
+    }
+
+    public Double getTotalDistance() { return totalDistance; }
+    public Long getTotalDuration() { return totalDuration; }
+    public Double getAveragePaceSeconds() { return averagePaceSeconds; }
+    public Integer getTotalCalories() { return totalCalories; }
+}

--- a/src/main/java/com/waytoearth/security/mock/MockAuthFilter.java
+++ b/src/main/java/com/waytoearth/security/mock/MockAuthFilter.java
@@ -1,0 +1,63 @@
+package com.waytoearth.security.mock;
+
+import com.waytoearth.security.AuthenticatedUser; // ✅ 진짜 principal import
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@Profile("postman")
+public class MockAuthFilter extends OncePerRequestFilter {
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String p = Optional.ofNullable(request.getServletPath()).orElse("");
+        return p.startsWith("/v3/api-docs")
+                || p.startsWith("/swagger-ui")
+                || p.startsWith("/actuator")
+                || p.equals("/health")
+                || p.equals("/ping");
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            // 기본값은 1L, 헤더로 오버라이드 가능
+            Long userId = Optional.ofNullable(request.getHeader("X-Mock-UserId"))
+                    .filter(s -> !s.isBlank())
+                    .map(Long::valueOf)
+                    .orElse(1L);
+
+            //  AuthenticatedUser는 userId 하나만 받음
+            AuthenticatedUser principal = new AuthenticatedUser(userId);
+
+            UsernamePasswordAuthenticationToken auth =
+                    new UsernamePasswordAuthenticationToken(
+                            principal,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                    );
+            auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/waytoearth/service/emblem/EmblemService.java
+++ b/src/main/java/com/waytoearth/service/emblem/EmblemService.java
@@ -1,0 +1,207 @@
+// com/waytoearth/service/emblem/EmblemService.java
+package com.waytoearth.service.emblem;
+
+import com.waytoearth.dto.response.emblem.EmblemAwardResult;
+import com.waytoearth.dto.response.emblem.EmblemCatalogItem;
+import com.waytoearth.dto.response.emblem.EmblemDetailResponse;
+import com.waytoearth.dto.response.emblem.EmblemSummaryResponse;
+import com.waytoearth.entity.Emblem;
+import com.waytoearth.entity.User;
+import com.waytoearth.entity.UserEmblem;
+import com.waytoearth.repository.EmblemRepository;
+import com.waytoearth.repository.UserEmblemRepository;
+import com.waytoearth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmblemService {
+
+    private final EmblemRepository emblemRepository;
+    private final UserRepository userRepository;
+    private final UserEmblemRepository userEmblemRepository;
+
+    /* =========================
+       조회 (요약/카탈로그/상세)
+       ========================= */
+
+    public EmblemSummaryResponse summary(Long userId) {
+        // 리포에 countByUserId가 없어도 동작하게 리스트 사이즈로 처리
+        int owned = userEmblemRepository.findByUserId(userId).size();
+        int total = (int) emblemRepository.count();
+        double completion = total == 0 ? 0.0 : (owned * 1.0 / total);
+
+        return EmblemSummaryResponse.builder()
+                .owned(owned)
+                .total(total)
+                .completionRate(completion)
+                .build();
+    }
+
+    /**
+     * 카탈로그(필터/커서/사이즈)
+     * - 리포에 커서/페이지 쿼리가 없어도 일단 동작하도록 메모리 필터링
+     *   (추후 findAllByOrderByIdDesc, findByIdLessThanOrderByIdDesc로 최적화 가능)
+     */
+    public List<EmblemCatalogItem> catalog(Long userId, String filter, int size, Long cursor) {
+        // 전체 엠블럼 로드 후 id desc 정렬
+        List<Emblem> all = emblemRepository.findAll();
+        all.sort(Comparator.comparing(Emblem::getId).reversed());
+
+        // 커서 적용: id < cursor
+        if (cursor != null) {
+            all = all.stream().filter(e -> e.getId() < cursor).collect(Collectors.toList());
+        }
+
+        // 보유 목록 한 번만 로드
+        Set<Long> ownedIds = userEmblemRepository.findByUserId(userId).stream()
+                .map(ue -> ue.getEmblem().getId())
+                .collect(Collectors.toSet());
+
+        String f = (filter == null ? "ALL" : filter.toUpperCase());
+        List<EmblemCatalogItem> mapped = new ArrayList<>();
+
+        for (Emblem e : all) {
+            boolean owned = ownedIds.contains(e.getId());
+            if ("OWNED".equals(f) && !owned) continue;
+            if ("MISSING".equals(f) && owned) continue;
+
+            mapped.add(EmblemCatalogItem.builder()
+                    .emblemId(e.getId())
+                    .name(e.getName())
+                    .description(e.getDescription())
+                    .imageUrl(e.getImageUrl())
+                    .rarity(e.getRarity())
+                    .owned(owned)
+                    .earnedAt(null) // 필요하면 UserEmblem에서 조회 확장
+                    .build());
+
+            if (mapped.size() >= size) break;
+        }
+        return mapped;
+    }
+
+    public EmblemDetailResponse detail(Long userId, Long emblemId) {
+        Emblem e = emblemRepository.findById(emblemId)
+                .orElseThrow(() -> new NoSuchElementException("Emblem not found: " + emblemId));
+
+        // 보유여부/획득일 조회 (리포에 전용 메서드 없어도 동작하도록 전체에서 검색)
+        Instant earnedAt = null;
+        boolean owned = false;
+        for (UserEmblem ue : userEmblemRepository.findByUserId(userId)) {
+            if (ue.getEmblem().getId().equals(emblemId)) {
+                owned = true;
+                earnedAt = ue.getAcquiredAt(); // 필드명이 earnedAt/acquiredAt 프로젝트 기준에 맞게
+                break;
+            }
+        }
+
+        return EmblemDetailResponse.builder()
+                .emblemId(e.getId())
+                .name(e.getName())
+                .description(e.getDescription())
+                .imageUrl(e.getImageUrl())
+                .rarity(e.getRarity())
+                .conditionType(e.getConditionType())
+                .conditionValue(e.getConditionValue())
+                .owned(owned)
+                .earnedAt(earnedAt)
+                .build();
+    }
+
+    /* =============
+       지급(발급)
+       ============= */
+
+    /**
+     * 단건 지급 시도 (멱등)
+     * - 이미 보유 시 false
+     * - 조건 미충족 시 false
+     * - 지급 성공 시 true
+     */
+    @Transactional
+    public boolean awardIfEligible(Long userId, Long emblemId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+        Emblem emblem = emblemRepository.findById(emblemId)
+                .orElseThrow(() -> new NoSuchElementException("Emblem not found: " + emblemId));
+
+        if (userEmblemRepository.existsByUserAndEmblem(user, emblem)) {
+            return false; // 이미 보유
+        }
+        if (!meetsCondition(user, emblem)) {
+            return false; // 조건 미충족
+        }
+
+        try {
+            userEmblemRepository.save(
+                    UserEmblem.builder()
+                            .user(user)
+                            .emblem(emblem)
+                            .acquiredAt(Instant.now())
+                            .build()
+            );
+            return true;
+        } catch (DataIntegrityViolationException dup) {
+            // 동시성 등으로 인한 UNIQUE 충돌 → 멱등 처리
+            return false;
+        }
+    }
+
+    /**
+     * 일괄 스캔 지급
+     * - scope: DISTANCE | ALL
+     * - 리포에 conditionType별 조회가 없어도 ALL 불러와 필터링
+     */
+    @Transactional
+    public EmblemAwardResult scanAndAward(Long userId, String scope) {
+        String type = scope == null ? "DISTANCE" : scope.toUpperCase();
+        List<Emblem> candidates = emblemRepository.findAll();
+
+        if (!"ALL".equals(type)) {
+            candidates = candidates.stream()
+                    .filter(e -> type.equalsIgnoreCase(nullToEmpty(e.getConditionType())))
+                    .collect(Collectors.toList());
+        }
+
+        List<Long> awardedIds = new ArrayList<>();
+        for (Emblem e : candidates) {
+            if (awardIfEligible(userId, e.getId())) {
+                awardedIds.add(e.getId());
+            }
+        }
+
+        return EmblemAwardResult.builder()
+                .awardedCount(awardedIds.size())
+                .awardedEmblemIds(awardedIds)
+                .build();
+    }
+
+    /* ==================
+       조건 평가 (간단판)
+       ================== */
+    private boolean meetsCondition(User user, Emblem emblem) {
+        String type = nullToEmpty(emblem.getConditionType()).toUpperCase();
+        BigDecimal target = emblem.getConditionValue();
+
+        return switch (type) {
+            case "DISTANCE" -> {
+                if (user.getTotalDistance() == null || target == null) yield false;
+                yield user.getTotalDistance().compareTo(target) >= 0;
+            }
+            // TODO: WEEKLY_GOAL, COURSE_COMPLETE 등 필요 시 추가
+            default -> false;
+        };
+    }
+
+    private String nullToEmpty(String s) { return s == null ? "" : s; }
+}

--- a/src/main/java/com/waytoearth/service/feed/FeedService.java
+++ b/src/main/java/com/waytoearth/service/feed/FeedService.java
@@ -1,0 +1,132 @@
+package com.waytoearth.service.feed;
+
+import com.waytoearth.dto.request.feed.FeedCreateRequest;
+import com.waytoearth.dto.response.feed.FeedResponse;
+import com.waytoearth.dto.response.feed.FeedLikeResponse;
+import com.waytoearth.entity.Feed;
+import com.waytoearth.entity.FeedLike;
+import com.waytoearth.entity.RunningRecord;
+import com.waytoearth.entity.User;
+import com.waytoearth.repository.FeedLikeRepository;
+import com.waytoearth.repository.FeedRepository;
+import com.waytoearth.repository.UserRepository;
+import com.waytoearth.repository.RunningRecordRepository;
+import com.waytoearth.security.AuthenticatedUser;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FeedService {
+
+    private final FeedRepository feedRepository;
+    private final FeedLikeRepository feedLikeRepository;
+    private final UserRepository userRepository;
+    private final RunningRecordRepository runningRecordRepository;
+
+    /**
+     * 피드 작성
+     */
+    @Transactional
+    public FeedResponse createFeed(AuthenticatedUser authUser, FeedCreateRequest req) {
+        User user = userRepository.findById(authUser.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        RunningRecord record = runningRecordRepository.findById(req.getRunningRecordId())
+                .orElseThrow(() -> new RuntimeException("Running record not found"));
+
+        Feed feed = Feed.builder()
+                .user(user)
+                .runningRecord(record)
+                .content(req.getContent())
+                .imageUrl(req.getImageUrl())
+                .build();
+
+        feedRepository.save(feed);
+
+        return FeedResponse.from(feed, false); // 작성 직후 liked=false
+    }
+
+    /**
+     * 피드 목록 조회 (무한 스크롤, 좋아요 여부 포함)
+     */
+    @Transactional(readOnly = true)
+    public List<FeedResponse> getFeeds(AuthenticatedUser authUser, int offset, int limit) {
+        User user = userRepository.findById(authUser.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        return feedRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(offset / limit, limit))
+                .stream()
+                .map(feed -> {
+                    boolean liked = feedLikeRepository.existsByFeedAndUser(feed, user);
+                    return FeedResponse.from(feed, liked);
+                })
+                .toList();
+    }
+
+    /**
+     * 피드 단건 조회 (좋아요 여부 포함)
+     */
+    @Transactional(readOnly = true)
+    public FeedResponse getFeed(AuthenticatedUser authUser, Long feedId) {
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new EntityNotFoundException("Feed not found"));
+        User user = userRepository.findById(authUser.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        boolean liked = feedLikeRepository.existsByFeedAndUser(feed, user);
+        return FeedResponse.from(feed, liked);
+    }
+
+    /**
+     * 피드 삭제
+     */
+    @Transactional
+    public void deleteFeed(AuthenticatedUser authUser, Long feedId) {
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new EntityNotFoundException("Feed not found"));
+
+        if (!feed.getUser().getId().equals(authUser.getUserId())) {
+            throw new IllegalStateException("본인이 작성한 피드만 삭제할 수 있습니다.");
+        }
+
+        feedRepository.delete(feed);
+    }
+
+    /**
+     * 피드 좋아요 (토글)
+     */
+    @Transactional
+    public FeedLikeResponse toggleLike(AuthenticatedUser authUser, Long feedId) {
+        User user = userRepository.findById(authUser.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new EntityNotFoundException("Feed not found"));
+
+        return feedLikeRepository.findByFeedAndUser(feed, user)
+                .map(existingLike -> {
+                    // 좋아요 취소
+                    feedLikeRepository.delete(existingLike);
+                    feed.setLikeCount(feed.getLikeCount() - 1); // ✅ DB 필드 업데이트
+                    feedRepository.save(feed); // ✅ 변경사항 반영
+                    return new FeedLikeResponse(feed.getId(), feed.getLikeCount(), false);
+                })
+                .orElseGet(() -> {
+                    // 좋아요 추가
+                    FeedLike like = FeedLike.builder()
+                            .feed(feed)
+                            .user(user)
+                            .build();
+                    feedLikeRepository.save(like);
+
+                    feed.setLikeCount(feed.getLikeCount() + 1); // ✅ DB 필드 업데이트
+                    feedRepository.save(feed); // ✅ 변경사항 반영
+                    return new FeedLikeResponse(feed.getId(), feed.getLikeCount(), true);
+                });
+    }
+}

--- a/src/main/java/com/waytoearth/service/file/FileService.java
+++ b/src/main/java/com/waytoearth/service/file/FileService.java
@@ -1,0 +1,134 @@
+// com/waytoearth/service/file/FileService.java
+package com.waytoearth.service.file;
+
+import com.waytoearth.dto.request.file.PresignRequest;
+import com.waytoearth.dto.response.file.PresignResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.Locale;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FileService {
+
+    private static final long MAX_SIZE = 5L * 1024 * 1024; // 5MB
+    private static final Duration EXPIRES_IN = Duration.ofMinutes(5);
+
+    private final S3Presigner presigner;
+
+    @Value("${cloud.aws.s3.bucket}") private String bucket;
+    @Value("${cloud.aws.region}")    private String region;
+
+    public PresignResponse presignProfile(Long userId, PresignRequest req) {
+        if (userId == null || userId <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 사용자 ID");
+        }
+        if (req == null) {
+            throw new IllegalArgumentException("요청이 비어 있습니다.");
+        }
+
+        final String contentType = safeLower(req.getContentType());
+        final long size = req.getSize();
+
+        // 1) 타입/사이즈 검증
+        if (contentType == null || !contentType.matches("^image/(jpeg|png|webp)$")) {
+            throw new IllegalArgumentException("허용되지 않는 Content-Type");
+        }
+        if (size <= 0 || size > MAX_SIZE) {
+            throw new IllegalArgumentException("파일 크기 초과(최대 5MB)");
+        }
+
+        // 2) 확장자는 contentType 기준으로 신뢰 (fileName의 확장자는 참고하지 않음)
+        final String ext = switch (contentType) {
+            case "image/jpeg" -> "jpg";
+            case "image/png"  -> "png";
+            case "image/webp" -> "webp";
+            default -> "bin";
+        };
+
+        // 3) 오브젝트 키 생성 (연/월/일/유저ID/UUID.ext)
+        LocalDate today = LocalDate.now();
+        String key = String.format(
+                "profiles/%d/%02d/%02d/%d/%s.%s",
+                today.getYear(), today.getMonthValue(), today.getDayOfMonth(),
+                userId, UUID.randomUUID(), ext
+        );
+
+        // 4) PutObject 요청 및 프리사인
+        PutObjectRequest put = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(contentType)
+                .contentLength(size)
+                .build();
+
+        PutObjectPresignRequest presignReq = PutObjectPresignRequest.builder()
+                .putObjectRequest(put)
+                .signatureDuration(EXPIRES_IN)
+                .build();
+
+        URL signedUrl = presigner.presignPutObject(presignReq).url();
+
+        // 5) 퍼블릭 접근 URL(버킷 퍼블릭/정책에 따라 접근 가능 여부 달라짐)
+        String publicUrl = String.format(
+                Locale.ROOT,
+                "https://%s.s3.%s.amazonaws.com/%s",
+                bucket, region, key
+        );
+
+        log.info("[S3 Presign] userId={}, key={}, contentType={}, size={}", userId, key, contentType, size);
+        return new PresignResponse(signedUrl.toString(), publicUrl, key, (int) EXPIRES_IN.getSeconds());
+    }
+
+    private static String safeLower(String v) {
+        return v == null ? null : v.toLowerCase(Locale.ROOT).trim();
+    }
+
+    // com/waytoearth/service/file/FileService.java
+
+    public PresignResponse presignFeed(Long userId, PresignRequest req) {
+        if (!req.getContentType().matches("^image/(jpeg|png|webp)$"))
+            throw new IllegalArgumentException("허용되지 않는 Content-Type");
+        if (req.getSize() > 5 * 1024 * 1024) // 피드 이미지라면 용량 제한 ↑
+            throw new IllegalArgumentException("파일 용량 초과 (최대 10MB)");
+
+        String key = String.format(
+                "feeds/%s/%s/%s",
+                LocalDate.now(),
+                userId,
+                UUID.randomUUID()
+        );
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(req.getContentType())
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5))
+                .putObjectRequest(objectRequest)
+                .build();
+
+        URL url = presigner.presignPutObject(presignRequest).url();
+
+        return new PresignResponse(
+                url.toString(),
+                String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key),
+                key,
+                300  // Presigned URL 만료 시간 (예: 300초)
+        );
+    }
+
+}

--- a/src/main/java/com/waytoearth/service/running/RunningService.java
+++ b/src/main/java/com/waytoearth/service/running/RunningService.java
@@ -1,0 +1,25 @@
+package com.waytoearth.service.running;
+
+import com.waytoearth.dto.request.running.*;
+import com.waytoearth.dto.response.running.*;
+import com.waytoearth.security.AuthenticatedUser;
+
+public interface RunningService {
+
+    RunningStartResponse startRunning(AuthenticatedUser user, RunningStartRequest request);
+
+    void updateRunning(AuthenticatedUser user, RunningUpdateRequest request);
+
+    //  공용 DTO로 통일
+    void pauseRunning(AuthenticatedUser user, RunningPauseResumeRequest request);
+
+    void resumeRunning(AuthenticatedUser user, RunningPauseResumeRequest request);
+
+    RunningCompleteResponse completeRunning(AuthenticatedUser user, RunningCompleteRequest request);
+
+    // 제목 수정
+    void updateTitle(AuthenticatedUser user, Long recordId, RunningTitleUpdateRequest request);
+
+    // 완료 페이지 재조회(경로 포함)
+    RunningCompleteResponse getDetail(AuthenticatedUser user, Long recordId);
+}

--- a/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
@@ -1,0 +1,208 @@
+package com.waytoearth.service.running;
+
+import com.waytoearth.dto.request.running.*;
+import com.waytoearth.dto.response.running.*;
+import com.waytoearth.entity.RunningRecord;
+import com.waytoearth.entity.User;
+import com.waytoearth.entity.enums.RunningStatus;
+import com.waytoearth.entity.enums.RunningType;
+import com.waytoearth.repository.RunningRecordRepository;
+import com.waytoearth.repository.RunningRouteRepository;
+import com.waytoearth.repository.UserRepository;
+import com.waytoearth.security.AuthenticatedUser;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RunningServiceImpl implements RunningService {
+
+    private final RunningRecordRepository runningRecordRepository;
+    private final RunningRouteRepository runningRouteRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public RunningStartResponse startRunning(AuthenticatedUser authUser, RunningStartRequest request) {
+        User runner = userRepository.findById(authUser.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // ✅ Builder 패턴으로 안전하게 생성
+        RunningRecord record = RunningRecord.builder()
+                .sessionId(request.getSessionId()) // ✅ 요청에서 받은 sessionId 사용
+                .user(runner)
+                .runningType(request.getRunningType() != null ? request.getRunningType() : RunningType.SINGLE)
+                .virtualCourseId(request.getVirtualCourseId())
+                .status(RunningStatus.RUNNING)
+                .startedAt(LocalDateTime.now())
+                .isCompleted(false) // ✅ 필수 필드 명시적 설정
+                .build();
+
+        runningRecordRepository.save(record);
+        return new RunningStartResponse(record.getSessionId(), record.getStartedAt());
+    }
+
+    @Override
+    public void updateRunning(AuthenticatedUser authUser, RunningUpdateRequest request) {
+        RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
+                .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
+
+        // 권한 검증 추가
+        if (!record.getUser().getId().equals(authUser.getUserId())) {
+            throw new IllegalArgumentException("해당 세션에 대한 권한이 없습니다.");
+        }
+
+        // 누적값 반영 (m → km)
+        record.setDistance(BigDecimal.valueOf(request.getDistanceMeters() / 1000.0));
+        record.setDuration(request.getDurationSeconds());
+        record.setAveragePaceSeconds(request.getAveragePaceSeconds());
+        record.setCalories(request.getCalories());
+
+        if (request.getCurrentPoint() != null) {
+            record.addRoutePoint(
+                    request.getCurrentPoint().getLatitude(),
+                    request.getCurrentPoint().getLongitude(),
+                    request.getCurrentPoint().getSequence()
+            );
+        }
+
+        runningRecordRepository.save(record); // ✅ 저장 추가
+    }
+
+    @Override
+    public void pauseRunning(AuthenticatedUser authUser, RunningPauseResumeRequest request) {
+        RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
+                .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
+
+        // 권한 검증 추가
+        if (!record.getUser().getId().equals(authUser.getUserId())) {
+            throw new IllegalArgumentException("해당 세션에 대한 권한이 없습니다.");
+        }
+
+        record.setStatus(RunningStatus.PAUSED);
+        runningRecordRepository.save(record); // ✅ 저장 추가
+    }
+
+    @Override
+    public void resumeRunning(AuthenticatedUser authUser, RunningPauseResumeRequest request) {
+        if (request.getSessionId() == null || request.getSessionId().isBlank()) {
+            throw new IllegalArgumentException("sessionId는 필수입니다.");
+        }
+
+        RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
+                .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
+
+        if (!record.getUser().getId().equals(authUser.getUserId())) {
+            throw new IllegalArgumentException("해당 세션에 대한 권한이 없습니다.");
+        }
+
+        record.setStatus(RunningStatus.RUNNING);
+        runningRecordRepository.save(record);
+    }
+
+
+    @Override
+    public RunningCompleteResponse completeRunning(AuthenticatedUser authUser, RunningCompleteRequest request) {
+        RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
+                .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
+
+        // 권한 검증 추가
+        if (!record.getUser().getId().equals(authUser.getUserId())) {
+            throw new IllegalArgumentException("해당 세션에 대한 권한이 없습니다.");
+        }
+
+        BigDecimal distanceKm = BigDecimal.valueOf(request.getDistanceMeters() / 1000.0);
+
+        // 도메인 메서드 사용: complete(...)
+        record.complete(
+                distanceKm,
+                request.getDurationSeconds(),
+                request.getAveragePaceSeconds(),
+                request.getCalories(),
+                LocalDateTime.now()
+        );
+
+        // 경로 전체 추가
+        if (request.getRoutePoints() != null) {
+            request.getRoutePoints().forEach(p ->
+                    record.addRoutePoint(p.getLatitude(), p.getLongitude(), p.getSequence())
+            );
+        }
+
+        // 사용자 통계 업데이트
+        User user = record.getUser();
+        user.updateRunningStats(distanceKm);
+        userRepository.save(user);
+
+        // 저장 후 응답 구성
+        runningRecordRepository.save(record);
+
+        return new RunningCompleteResponse(
+                record.getId(),
+                record.getTitle(), // 제목은 PATCH로 수정 가능
+                record.getDistance() != null ? record.getDistance().doubleValue() : 0.0,
+                formatPace(record.getAveragePaceSeconds()),
+                record.getCalories(),
+                record.getStartedAt() != null ? record.getStartedAt().toString() : null,
+                record.getEndedAt() != null ? record.getEndedAt().toString() : null,
+                record.getRoutes().stream()
+                        .map(rt -> new RunningCompleteResponse.RoutePoint(
+                                rt.getLatitude(), rt.getLongitude(), rt.getSequence()
+                        ))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public void updateTitle(AuthenticatedUser authUser, Long recordId, RunningTitleUpdateRequest request) {
+        RunningRecord record = runningRecordRepository.findById(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("기록을 찾을 수 없습니다."));
+
+        // 소유권 검증
+        if (!record.getUser().getId().equals(authUser.getUserId())) {
+            throw new IllegalArgumentException("해당 기록에 대한 권한이 없습니다.");
+        }
+
+        record.setTitle(request.getTitle());
+        runningRecordRepository.save(record); // ✅ 저장 추가
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public RunningCompleteResponse getDetail(AuthenticatedUser authUser, Long recordId) {
+        RunningRecord r = runningRecordRepository.findWithRoutesById(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("기록을 찾을 수 없습니다."));
+
+        // 소유권 검증
+        if (!r.getUser().getId().equals(authUser.getUserId())) {
+            throw new IllegalArgumentException("해당 기록에 대한 권한이 없습니다.");
+        }
+
+        return new RunningCompleteResponse(
+                r.getId(),
+                r.getTitle(),
+                r.getDistance() != null ? r.getDistance().doubleValue() : 0.0,
+                formatPace(r.getAveragePaceSeconds()),
+                r.getCalories(),
+                r.getStartedAt() != null ? r.getStartedAt().toString() : null,
+                r.getEndedAt() != null ? r.getEndedAt().toString() : null,
+                r.getRoutes().stream()
+                        .map(rt -> new RunningCompleteResponse.RoutePoint(
+                                rt.getLatitude(), rt.getLongitude(), rt.getSequence()
+                        ))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    private String formatPace(Integer paceSeconds) {
+        if (paceSeconds == null) return "00:00";
+        int m = paceSeconds / 60;
+        int s = paceSeconds % 60;
+        return String.format("%02d:%02d", m, s);
+    }
+}

--- a/src/main/java/com/waytoearth/service/user/UserService.java
+++ b/src/main/java/com/waytoearth/service/user/UserService.java
@@ -1,14 +1,23 @@
 package com.waytoearth.service.user;
-
+import java.math.RoundingMode;
 import com.waytoearth.dto.request.auth.OnboardingRequest;
+import com.waytoearth.dto.request.user.UserUpdateRequest;
+import com.waytoearth.dto.response.user.UserInfoResponse;
+import com.waytoearth.dto.response.user.UserSummaryResponse;
 import com.waytoearth.entity.User;
 import com.waytoearth.exception.DuplicateResourceException;
 import com.waytoearth.exception.UserNotFoundException;
+import com.waytoearth.repository.EmblemRepository;
+import com.waytoearth.repository.UserEmblemRepository;
 import com.waytoearth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZoneOffset;
+
+import java.time.Instant;
 
 @Service
 @RequiredArgsConstructor
@@ -17,13 +26,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    // ✅ 엠블럼 요약 계산용 리포지토리 주입
+    private final UserEmblemRepository userEmblemRepository;
+    private final EmblemRepository emblemRepository;
 
     /**
      * 카카오 ID로 사용자 조회
      */
     public User findByKakaoId(Long kakaoId) {
-        return userRepository.findByKakaoId(kakaoId)
-                .orElse(null);
+        return userRepository.findByKakaoId(kakaoId).orElse(null);
     }
 
     /**
@@ -40,11 +51,9 @@ public class UserService {
     @Transactional
     public User createUser(Long kakaoId) {
         log.info("[UserService] 신규 사용자 생성 - kakaoId: {}", kakaoId);
-
         User newUser = User.builder()
                 .kakaoId(kakaoId)
                 .build();
-
         return userRepository.save(newUser);
     }
 
@@ -55,15 +64,12 @@ public class UserService {
     public void completeOnboarding(Long userId, OnboardingRequest request) {
         log.info("[UserService] 온보딩 완료 요청 - userId: {}, nickname: {}", userId, request.getNickname());
 
-        // 1. 사용자 조회
         User user = findById(userId);
 
-        // 2. 닉네임 중복 검사
         if (userRepository.existsByNickname(request.getNickname())) {
             throw new DuplicateResourceException("이미 사용 중인 닉네임입니다: " + request.getNickname());
         }
 
-        // 3. 온보딩 정보 업데이트
         user.completeOnboarding(
                 request.getNickname(),
                 request.getResidence(),
@@ -82,5 +88,99 @@ public class UserService {
      */
     public boolean existsByNickname(String nickname) {
         return userRepository.existsByNickname(nickname);
+    }
+
+    // =========================
+    // 👇 여기부터 추가된 구현
+    // =========================
+
+    /**
+     * 내 정보 조회 (GET /v1/users/me)
+     */
+
+    public UserInfoResponse getMe(Long userId) {
+        User u = findById(userId);
+
+        String ageGroup = (u.getAgeGroup() == null) ? null : u.getAgeGroup().name();     // or .getLabel()
+        String gender   = (u.getGender()   == null) ? null : u.getGender().name();       // or .getLabel()
+        Instant created = (u.getCreatedAt()== null) ? null : u.getCreatedAt()
+                .atOffset(ZoneOffset.UTC).toInstant();
+
+        return new UserInfoResponse(
+                u.getId(),
+                u.getNickname(),
+                u.getProfileImageUrl(),
+                u.getResidence(),
+                ageGroup,
+                gender,
+                u.getWeeklyGoalDistance(),
+                u.getTotalDistance(),
+                u.getTotalRunningCount(),
+                created
+        );
+    }
+    /**
+     * 내 정보 요약 (GET /v1/users/me/summary)
+     * - 보유 엠블럼 수 / 전체 엠블럼 수 = completion_rate
+     * - 총거리/러닝 횟수는 users 테이블의 캐시 필드 사용
+     */
+    public UserSummaryResponse getSummary(Long userId) {
+        int owned = (int) userEmblemRepository.countByUserId(userId);
+        int total = (int) emblemRepository.count();
+        double completion = (total == 0) ? 0.0 : (owned * 1.0 / total);
+
+        User u = findById(userId);
+        double totalDistance = (u.getTotalDistance() == null) ? 0.0 : u.getTotalDistance().doubleValue();
+        int totalCount = (u.getTotalRunningCount() == null) ? 0 : u.getTotalRunningCount();
+
+        return new UserSummaryResponse(completion, owned, totalDistance, totalCount);
+    }
+
+    /**
+     * 프로필 수정 (PUT /v1/users/me)
+     * - 닉네임, 프로필 이미지 URL, 거주지, 주간 목표 거리 (부분 수정 가능)
+     * - 닉네임은 변경 시 중복 체크
+     */
+    @Transactional
+    public void updateProfile(Long userId, UserUpdateRequest req) {
+        User u = findById(userId);
+
+        // 닉네임
+        if (req.getNickname() != null) {
+            String newNickname = req.getNickname().trim();
+            if (!newNickname.isEmpty() && !newNickname.equals(u.getNickname())) {
+                if (userRepository.existsByNickname(newNickname)) {
+                    throw new DuplicateResourceException("닉네임이 이미 존재합니다.");
+                }
+                u.setNickname(newNickname);
+            }
+        }
+
+        // 프로필 이미지 URL
+        if (req.getProfileImageUrl() != null) {
+            String url = req.getProfileImageUrl().trim();
+            if (!url.isEmpty()) {
+                u.setProfileImageUrl(url);
+            }
+        }
+
+        // 거주지
+        if (req.getResidence() != null) {
+            String resi = req.getResidence().trim();
+            if (!resi.isEmpty()) {
+                u.setResidence(resi);
+            }
+        }
+
+        // 주간 목표 거리
+        if (req.getWeeklyGoalDistance() != null) {
+            var normalized = req.getWeeklyGoalDistance().setScale(2, RoundingMode.HALF_UP);
+            u.setWeeklyGoalDistance(normalized);
+        }
+
+        userRepository.save(u);
+
+        log.info("[Users:Update] userId={}, nickname={}, residence={}, weeklyGoalDistance={}",
+                u.getId(), u.getNickname(), u.getResidence(), u.getWeeklyGoalDistance());
     }
 }

--- a/src/main/java/com/waytoearth/service/weather/WeatherService.java
+++ b/src/main/java/com/waytoearth/service/weather/WeatherService.java
@@ -1,0 +1,7 @@
+package com.waytoearth.service.weather;
+
+import com.waytoearth.dto.response.weather.WeatherCurrentResponse;
+
+public interface WeatherService {
+    WeatherCurrentResponse getCurrent(double lat, double lon);
+}

--- a/src/main/java/com/waytoearth/service/weather/WeatherServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/weather/WeatherServiceImpl.java
@@ -1,0 +1,63 @@
+package com.waytoearth.service.weather;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.waytoearth.dto.response.weather.WeatherCurrentResponse;
+import com.waytoearth.entity.enums.WeatherCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class WeatherServiceImpl implements WeatherService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${weather.openweather.api-key:}")
+    private String apiKey;
+
+    @Override
+    public WeatherCurrentResponse getCurrent(double lat, double lon) {
+        // API 키가 없으면 기본값 반환 (요구사항)
+        if (apiKey == null || apiKey.isBlank()) {
+            return WeatherCurrentResponse.ofFallback(WeatherCondition.UNKNOWN);
+        }
+
+        String url = String.format(
+                "https://api.openweathermap.org/data/2.5/weather?lat=%f&lon=%f&appid=%s&units=metric",
+                lat, lon, apiKey
+        );
+
+        try {
+            ResponseEntity<String> res = restTemplate.getForEntity(url, String.class);
+            JsonNode root = objectMapper.readTree(res.getBody());
+
+            // OpenWeather main: "Clear", "Clouds", "Rain", "Snow", "Drizzle", "Thunderstorm", "Mist", ...
+            String main = root.path("weather").get(0).path("main").asText("");
+            String icon = root.path("weather").get(0).path("icon").asText(""); // e.g. "10d"
+
+            WeatherCondition condition = WeatherCondition.fromOpenWeatherMain(main);
+
+            return WeatherCurrentResponse.builder()
+                    .condition(condition)
+                    .emoji(condition.getEmoji())
+                    .iconCode(icon) // 프론트가 자체 아이콘 쓰면 무시해도 OK
+                    .fetchedAt(LocalDateTime.now())
+                    .recommendation(condition.getRecommendation()) // 아래 DTO 참고
+                    .build();
+
+        } catch (RestClientException | NullPointerException e) {
+            // 외부 호출 실패 시 안전한 기본값
+            return WeatherCurrentResponse.ofFallback(WeatherCondition.UNKNOWN);
+        } catch (Exception e) {
+            return WeatherCurrentResponse.ofFallback(WeatherCondition.UNKNOWN);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,80 @@
+#spring:
+#  application:
+#    name: waytoearth-backend
+#
+#  config:
+#    import: optional:dotenv:.env
+#
+#  security:
+#    oauth2:
+#      client:
+#        registration:
+#          kakao:
+#            client-id: ${KAKAO_CLIENT_ID}
+#            redirect-uri: ${KAKAO_REDIRECT_URI}
+#            authorization-grant-type: authorization_code
+#            client-authentication-method: POST
+#            scope:
+#              - profile_nickname
+#              - account_email
+#        provider:
+#          kakao:
+#            authorization-uri: https://kauth.kakao.com/oauth/authorize
+#            token-uri: ${KAKAO_TOKEN_URI}
+#            user-info-uri: ${KAKAO_USER_INFO_URI}
+#            user-name-attribute: id
+#
+#  datasource:
+#    url: ${DB_URL}
+#    username: ${DB_USERNAME}
+#    password: ${DB_PASSWORD}
+#    driver-class-name: org.mariadb.jdbc.Driver
+#
+#  jpa:
+#    hibernate:
+#      ddl-auto:
+#    show-sql: true
+#    properties:
+#      hibernate:
+#        format_sql: true
+#        dialect: org.hibernate.dialect.MariaDBDialect
+#    open-in-view: false
+#
+## 기존 KakaoApiService가 사용하는 설정.
+#kakao:
+#  client-id: ${KAKAO_CLIENT_ID}
+#  redirect-uri: ${KAKAO_REDIRECT_URI}
+#
+## JWT 설정
+#jwt:
+#  secret: ${JWT_SECRET}
+#  expiration: 86400000
+#
+## 서버 설정
+#server:
+#  address: 0.0.0.0
+#  port: 8080
+#
+## Swagger 설정
+#springdoc:
+#  swagger-ui:
+#    path: /swagger-ui.html
+#    tags-sorter: alpha
+#    operations-sorter: alpha
+#  api-docs:
+#    path: /v3/api-docs
+#
+## 로깅 설정.
+#logging:
+#  level:
+#    org.hibernate.SQL: DEBUG
+#    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+#    org.springframework.security: DEBUG
+#    com.waytoearth: DEBUG
+#    org.springframework.web.reactive: DEBUG
+
+
+
 spring:
   application:
     name: waytoearth-backend
@@ -32,7 +109,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
@@ -40,7 +117,7 @@ spring:
         dialect: org.hibernate.dialect.MariaDBDialect
     open-in-view: false
 
-# 기존 KakaoApiService가 사용하는 설정.
+# KakaoApiService 설정
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: ${KAKAO_REDIRECT_URI}
@@ -49,6 +126,13 @@ kakao:
 jwt:
   secret: ${JWT_SECRET}
   expiration: 86400000
+
+# AWS S3 설정 (추가)
+cloud:
+  aws:
+    region: ${AWS_REGION:ap-northeast-2}
+    s3:
+      bucket: ${S3_BUCKET:waytoearth-assets}
 
 # 서버 설정
 server:
@@ -64,7 +148,7 @@ springdoc:
   api-docs:
     path: /v3/api-docs
 
-# 로깅 설정.
+# 로깅 설정
 logging:
   level:
     org.hibernate.SQL: DEBUG


### PR DESCRIPTION
## #️⃣ 연관 이슈

---

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [x] 기능 추가
* [ ] 기능 삭제
* [ ] 버그 수정
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

### 이번 PR에서 작업한 내용을 간략히 설명해주세요

####  내 정보(User) 기능

* `UserController`

  * **내 정보 조회** (`GET /v1/users/me`)
  * **내 정보 요약** (`GET /v1/users/me/summary`)
  * **프로필 수정** (`PUT /v1/users/me`) – 닉네임, 거주지, 프로필 이미지, 주간 목표 거리 업데이트 가능
* `UserService`

  * 닉네임 중복 검증 및 수정 로직 추가
  * `UserInfoResponse`, `UserSummaryResponse` DTO 작성
  * 엠블럼 보유 현황과 누적 러닝 통계 연동

####  피드(Feed) 기능

* `FeedController`

  * 피드 작성 (`POST /v1/feeds`)
  * 피드 목록 조회 (무한 스크롤, 좋아요 여부 포함) (`GET /v1/feeds`)
  * 피드 단건 조회 (`GET /v1/feeds/{id}`)
  * 피드 삭제 (`DELETE /v1/feeds/{id}`)
  * 좋아요 토글 (`POST /v1/feeds/{id}/like`)
* `FeedService`

  * 피드 작성 시 RunningRecord 연동 가능
  * 좋아요 시 `feed_likes` 테이블과 `likeCount` 동기화
  * 무한 스크롤 기반 페이징 처리
* DTO

  * `FeedCreateRequest`, `FeedResponse`, `FeedLikeResponse`, `PageResponse`

####  AWS S3 Presigned URL 연동

* `FileController`

  * **프로필 이미지 Presigned URL 발급** (`POST /v1/files/presign/profile`)
  * **피드 이미지 Presigned URL 발급** (`POST /v1/files/presign/feed`)
* `FileService`

  * S3 업로드 Presigned URL 생성 로직 구현
  * 파일 타입/사이즈 검증 추가 (프로필 ≤ 5MB, 피드 ≤ 10MB)
  * 업로드 URL + Public 접근 URL 함께 반환
* 설정

  * `AwsS3Config` → `S3Presigner` Bean 등록
  * `application.yml` → `cloud.aws.s3.bucket`, `cloud.aws.region` 환경변수 설정 추가

---

### 테스트 결과 or 스크린샷 (선택)



---

##  리뷰 요구사항 (선택)

* 프로필 수정 시 **닉네임 중복 검증 로직**이 현재 `UserService`에 포함되어 있는데, 컨트롤러 레벨에서 예외 처리하는 게 나을지 검토 필요합니다.
* 피드 무한 스크롤 시 offset/limit 방식으로 구현했는데, 성능 고려 시 cursor 기반으로 개선하는 게 좋을지 의견 부탁드립니다.


