### PR TITLE
[FEAT] S3 동기화/이미지 변경 및 삭제시 중복 저장 방지 로직 추가 및 수정

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/FileController.java
+++ b/src/main/java/com/waytoearth/controller/v1/FileController.java
@@ -3,9 +3,10 @@ package com.waytoearth.controller.v1;
 
 import com.waytoearth.dto.request.file.PresignRequest;
 import com.waytoearth.dto.response.file.PresignResponse;
-import com.waytoearth.security.AuthenticatedUser;
 import com.waytoearth.security.AuthUser;
+import com.waytoearth.security.AuthenticatedUser;
 import com.waytoearth.service.file.FileService;
+import com.waytoearth.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class FileController {
 
     private final FileService fileService;
+    private final UserService userService;
 
     @Operation(summary = "프로필 이미지 업로드 Presigned URL 발급", description = "사용자가 프로필 이미지를 업로드할 수 있도록 S3 Presigned URL을 발급한다.")
     @PostMapping("/presign/profile")
@@ -37,5 +39,12 @@ public class FileController {
             @Valid @RequestBody PresignRequest request
     ) {
         return ResponseEntity.ok(fileService.presignFeed(me.getUserId(), request));
+    }
+
+
+    @DeleteMapping("/profile")
+    public ResponseEntity<Void> deleteProfileImage(@AuthUser AuthenticatedUser me) {
+        userService.removeProfileImage(me.getUserId());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/waytoearth/dto/request/user/UserUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/user/UserUpdateRequest.java
@@ -1,9 +1,11 @@
 // com/waytoearth/dto/request/user/UserUpdateRequest.java
 package com.waytoearth.dto.request.user;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -31,4 +33,8 @@ public class UserUpdateRequest {
         @DecimalMin(value = "0.01")
         @DecimalMax(value = "999.99")
         private BigDecimal weeklyGoalDistance;
+
+        //  S3 key도 함께 전달 (삭제/교체 시 필요)
+        @JsonProperty("profile_image_key")
+        private String profileImageKey;
 }

--- a/src/main/java/com/waytoearth/entity/Feed.java
+++ b/src/main/java/com/waytoearth/entity/Feed.java
@@ -34,6 +34,10 @@ public class Feed {
     @Column(name = "image_url")
     private String imageUrl;
 
+    // S3 삭제를 위해 Key 보관
+    @Column(name = "image_key")
+    private String imageKey;
+
     @Column(name = "like_count", nullable = false)
     private int likeCount = 0;
 

--- a/src/main/java/com/waytoearth/entity/User.java
+++ b/src/main/java/com/waytoearth/entity/User.java
@@ -52,6 +52,11 @@ public class User {
     @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
+    // S3 삭제를 위해 Key도 보관
+    @Setter
+    @Column(name = "profile_image_key", length = 500)
+    private String profileImageKey;
+
     @Column(name = "is_onboarding_completed", nullable = false)
     @Builder.Default
     private Boolean isOnboardingCompleted = false;

--- a/src/main/java/com/waytoearth/service/feed/FeedService.java
+++ b/src/main/java/com/waytoearth/service/feed/FeedService.java
@@ -1,17 +1,18 @@
 package com.waytoearth.service.feed;
 
 import com.waytoearth.dto.request.feed.FeedCreateRequest;
-import com.waytoearth.dto.response.feed.FeedResponse;
 import com.waytoearth.dto.response.feed.FeedLikeResponse;
+import com.waytoearth.dto.response.feed.FeedResponse;
 import com.waytoearth.entity.Feed;
 import com.waytoearth.entity.FeedLike;
 import com.waytoearth.entity.RunningRecord;
 import com.waytoearth.entity.User;
 import com.waytoearth.repository.FeedLikeRepository;
 import com.waytoearth.repository.FeedRepository;
-import com.waytoearth.repository.UserRepository;
 import com.waytoearth.repository.RunningRecordRepository;
+import com.waytoearth.repository.UserRepository;
 import com.waytoearth.security.AuthenticatedUser;
+import com.waytoearth.service.file.FileService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -28,6 +29,7 @@ public class FeedService {
     private final FeedLikeRepository feedLikeRepository;
     private final UserRepository userRepository;
     private final RunningRecordRepository runningRecordRepository;
+    private final FileService fileService;
 
     /**
      * 피드 작성
@@ -93,6 +95,11 @@ public class FeedService {
 
         if (!feed.getUser().getId().equals(authUser.getUserId())) {
             throw new IllegalStateException("본인이 작성한 피드만 삭제할 수 있습니다.");
+        }
+
+        // ✅ S3 삭제
+        if (feed.getImageKey() != null) {
+            fileService.deleteObject(feed.getImageKey());
         }
 
         feedRepository.delete(feed);

--- a/src/main/java/com/waytoearth/service/file/FileService.java
+++ b/src/main/java/com/waytoearth/service/file/FileService.java
@@ -1,4 +1,3 @@
-// com/waytoearth/service/file/FileService.java
 package com.waytoearth.service.file;
 
 import com.waytoearth.dto.request.file.PresignRequest;
@@ -7,6 +6,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -30,26 +32,19 @@ public class FileService {
     @Value("${cloud.aws.s3.bucket}") private String bucket;
     @Value("${cloud.aws.region}")    private String region;
 
+    //  프로필 이미지 Presign
     public PresignResponse presignProfile(Long userId, PresignRequest req) {
-        if (userId == null || userId <= 0) {
-            throw new IllegalArgumentException("유효하지 않은 사용자 ID");
-        }
-        if (req == null) {
-            throw new IllegalArgumentException("요청이 비어 있습니다.");
-        }
+        if (userId == null || userId <= 0) throw new IllegalArgumentException("유효하지 않은 사용자 ID");
+        if (req == null) throw new IllegalArgumentException("요청이 비어 있습니다.");
 
         final String contentType = safeLower(req.getContentType());
         final long size = req.getSize();
 
-        // 1) 타입/사이즈 검증
-        if (contentType == null || !contentType.matches("^image/(jpeg|png|webp)$")) {
+        if (contentType == null || !contentType.matches("^image/(jpeg|png|webp)$"))
             throw new IllegalArgumentException("허용되지 않는 Content-Type");
-        }
-        if (size <= 0 || size > MAX_SIZE) {
+        if (size <= 0 || size > MAX_SIZE)
             throw new IllegalArgumentException("파일 크기 초과(최대 5MB)");
-        }
 
-        // 2) 확장자는 contentType 기준으로 신뢰 (fileName의 확장자는 참고하지 않음)
         final String ext = switch (contentType) {
             case "image/jpeg" -> "jpg";
             case "image/png"  -> "png";
@@ -57,15 +52,9 @@ public class FileService {
             default -> "bin";
         };
 
-        // 3) 오브젝트 키 생성 (연/월/일/유저ID/UUID.ext)
-        LocalDate today = LocalDate.now();
-        String key = String.format(
-                "profiles/%d/%02d/%02d/%d/%s.%s",
-                today.getYear(), today.getMonthValue(), today.getDayOfMonth(),
-                userId, UUID.randomUUID(), ext
-        );
+        //  항상 userId 기반 고정 key 사용 → 중복 방지
+        String key = String.format("profiles/%d/profile.%s", userId, ext);
 
-        // 4) PutObject 요청 및 프리사인
         PutObjectRequest put = PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)
@@ -80,35 +69,20 @@ public class FileService {
 
         URL signedUrl = presigner.presignPutObject(presignReq).url();
 
-        // 5) 퍼블릭 접근 URL(버킷 퍼블릭/정책에 따라 접근 가능 여부 달라짐)
-        String publicUrl = String.format(
-                Locale.ROOT,
-                "https://%s.s3.%s.amazonaws.com/%s",
-                bucket, region, key
-        );
+        String publicUrl = String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
 
-        log.info("[S3 Presign] userId={}, key={}, contentType={}, size={}", userId, key, contentType, size);
+        log.info("[S3 Presign Profile] userId={}, key={}, contentType={}, size={}", userId, key, contentType, size);
         return new PresignResponse(signedUrl.toString(), publicUrl, key, (int) EXPIRES_IN.getSeconds());
     }
 
-    private static String safeLower(String v) {
-        return v == null ? null : v.toLowerCase(Locale.ROOT).trim();
-    }
-
-    // com/waytoearth/service/file/FileService.java
-
+    //  피드 이미지 Presign
     public PresignResponse presignFeed(Long userId, PresignRequest req) {
         if (!req.getContentType().matches("^image/(jpeg|png|webp)$"))
             throw new IllegalArgumentException("허용되지 않는 Content-Type");
-        if (req.getSize() > 5 * 1024 * 1024) // 피드 이미지라면 용량 제한 ↑
+        if (req.getSize() > 10 * 1024 * 1024)
             throw new IllegalArgumentException("파일 용량 초과 (최대 10MB)");
 
-        String key = String.format(
-                "feeds/%s/%s/%s",
-                LocalDate.now(),
-                userId,
-                UUID.randomUUID()
-        );
+        String key = String.format("feeds/%s/%s/%s", LocalDate.now(), userId, UUID.randomUUID());
 
         PutObjectRequest objectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
@@ -117,7 +91,7 @@ public class FileService {
                 .build();
 
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(5))
+                .signatureDuration(EXPIRES_IN)
                 .putObjectRequest(objectRequest)
                 .build();
 
@@ -127,8 +101,23 @@ public class FileService {
                 url.toString(),
                 String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key),
                 key,
-                300  // Presigned URL 만료 시간 (예: 300초)
+                (int) EXPIRES_IN.getSeconds()
         );
     }
 
+    //  S3 삭제
+    public void deleteObject(String key) {
+        if (key == null || key.isBlank()) return;
+        try (S3Client s3 = S3Client.builder().region(Region.of(region)).build()) {
+            s3.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build());
+            log.info("[S3 Delete] key={}", key);
+        }
+    }
+
+    private static String safeLower(String v) {
+        return v == null ? null : v.toLowerCase(Locale.ROOT).trim();
+    }
 }


### PR DESCRIPTION
##  연관 이슈

>  #37 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [x] 기능 추가
* [x] 버그 수정

### 이번 PR에서 작업한 내용을 간략히 설명해주세요

* **FileService**

  * `deleteObject(String key)` 메서드 추가 (S3 객체 삭제 기능)
  * `presignProfile()` 수정 → userId 기반 고정 key 사용으로 중복 방지

* **User 엔티티**

  * `profileImageKey` 필드 추가 (기존 URL만 저장하던 구조 보완)

* **Feed 엔티티**

  * `imageKey` 필드 추가 (피드 삭제 시 S3 객체 삭제 가능하도록 개선)

* **UserService**

  * `updateProfile()` 수정 → 프로필 교체 시 기존 S3 객체 자동 삭제
  * `removeProfileImage()` 추가 → 프로필 이미지 제거 시 S3 삭제 및 필드 초기화

* **FeedService**

  * `deleteFeed()` 수정 → 피드 삭제 시 S3 객체도 함께 삭제

* **FileController**

  * `DELETE /v1/files/profile` API 추가 → 사용자 프로필 이미지 제거

* **UserUpdateRequest DTO**

  * `profileImageKey` 필드 추가 → 교체/삭제 시 서버로 Key 전달 가능

