### PR TITLE
[FEAT] FileService ContentLength 제거

### DIFF
--- a/src/main/java/com/waytoearth/service/file/FileService.java
+++ b/src/main/java/com/waytoearth/service/file/FileService.java
@@ -59,7 +59,7 @@ public class FileService {
                 .bucket(bucket)
                 .key(key)
                 .contentType(contentType)
-                .contentLength(size)
+//                .contentLength(size)
                 .build();
 
         PutObjectPresignRequest presignReq = PutObjectPresignRequest.builder()
@@ -71,7 +71,9 @@ public class FileService {
 
         String publicUrl = String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
 
-        log.info("[S3 Presign Profile] userId={}, key={}, contentType={}, size={}", userId, key, contentType, size);
+        log.info("[S3 Presign Profile] bucket={}, region={}, userId={}, key={}, uploadUrl={}, publicUrl={}",
+                bucket, region, userId, key, signedUrl, publicUrl);
+
         return new PresignResponse(signedUrl.toString(), publicUrl, key, (int) EXPIRES_IN.getSeconds());
     }
 

--- a/src/main/java/com/waytoearth/service/user/UserService.java
+++ b/src/main/java/com/waytoearth/service/user/UserService.java
@@ -160,20 +160,21 @@ public class UserService {
             }
         }
 
-        // 🔹 프로필 이미지 (URL + Key)
+// 🔹 프로필 이미지 (URL + Key)
         if (req.getProfileImageUrl() != null && req.getProfileImageKey() != null) {
             String newUrl = req.getProfileImageUrl().trim();
             String newKey = req.getProfileImageKey().trim();
 
             if (!newUrl.isEmpty() && !newKey.isEmpty()) {
-                // ✅ 기존 프로필 이미지 있으면 삭제
-                if (u.getProfileImageKey() != null) {
-                    fileService.deleteObject(u.getProfileImageKey());
-                }
+                // ❌ 고정 키 방식에서는 굳이 삭제할 필요 없음
+                // if (u.getProfileImageKey() != null) {
+                //     fileService.deleteObject(u.getProfileImageKey());
+                // }
                 u.setProfileImageUrl(newUrl);
                 u.setProfileImageKey(newKey);
             }
         }
+
 
         // 🔹 거주지
         if (req.getResidence() != null) {


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #37 #38 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
* [ ] 기능 추가
* [ ] 기능 삭제
* [x] 버그 수정
* [] 의존성, 환경 변수, 빌드 관련 코드 업데이트


> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 현재 DB에는 profiles/1/profile.jpg가 저장됐지만, S3에는 없음 → contentLength 때문에 업로드가 무효화된 것으로 보임.

백엔드 presignProfile에서 contentLength 제거 + 프론트는 signedUrl만 PUT + Content-Type만 헤더로 설정.

### 테스트 결과 or 스크린샷 (선택)
> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요