### PR TITLE
[FEAT] Feed 및  Profile S3 중복 저장 방지 로직 최종

### DIFF
--- a/src/main/java/com/waytoearth/dto/request/feed/FeedCreateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/feed/FeedCreateRequest.java
@@ -14,4 +14,7 @@ public class FeedCreateRequest {
 
     @Schema(description = "이미지 URL (S3 업로드 후 경로)", example = "https://example.com/running_photo.jpg")
     private String imageUrl;
+
+    @Schema(description = "이미지 Key (S3 삭제 시 필요)", example = "feeds/2025-08-24/1/uuid1234")
+    private String imageKey; // ✅ 추가
 }

--- a/src/main/java/com/waytoearth/service/feed/FeedService.java
+++ b/src/main/java/com/waytoearth/service/feed/FeedService.java
@@ -47,6 +47,7 @@ public class FeedService {
                 .runningRecord(record)
                 .content(req.getContent())
                 .imageUrl(req.getImageUrl())
+                .imageKey(req.getImageKey())
                 .build();
 
         feedRepository.save(feed);


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #38 

---

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [x] 버그 수정

---

###  이번 PR에서 작업한 내용을 간략히 설명해주세요

* **Feed & Profile 이미지 업로드 개선**

  * presign 응답 시 `imageKey`를 함께 저장하도록 수정
  * 프론트엔드에서 `imageKey`를 백엔드로 전달 → DB에 `imageUrl` + `imageKey` 모두 저장
  * Feed 삭제 시 `fileService.deleteObject(imageKey)` 호출로 S3 객체 삭제 동작 확인
  * Profile 이미지 수정 로직에서도 동일하게 `profile_image_key` 기반 삭제 보장

* **중복 저장 방지 로직 적용**

  * 동일한 이미지가 URL만 저장되고 Key 미저장 → S3 삭제 불가 문제 해결
  * 이제 Feed 및 Profile 모두 S3 Key 기반으로 일관성 있게 관리

---

###  테스트 결과 or 스크린샷

---

###  리뷰 요구사항 (선택)

