### PR TITLE
[Feat] 런닝 통계 및 조회 API 보완 (DTO/엔티티 매핑 안정화, @NoArgsConstructor 추가

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/RunningController.java
+++ b/src/main/java/com/waytoearth/controller/v1/RunningController.java
@@ -3,13 +3,18 @@ package com.waytoearth.controller.v1;
 
 import com.waytoearth.dto.request.running.*;
 import com.waytoearth.dto.response.running.*;
-import com.waytoearth.service.running.RunningService;
 import com.waytoearth.security.AuthUser;
 import com.waytoearth.security.AuthenticatedUser;
+import com.waytoearth.service.running.RunningService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/v1/running")
@@ -78,4 +83,29 @@ public class RunningController {
             @PathVariable Long recordId) {
         return ResponseEntity.ok(runningService.getDetail(user, recordId));
     }
+
+    @Operation(summary = "러닝 기록 목록 조회 (페이징)")
+    @GetMapping("/records")
+    public ResponseEntity<?> getRecords(
+            @AuthUser AuthenticatedUser user,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<RunningRecordSummaryResponse> pageResult = runningService.getRecords(user, pageable);
+
+        // ✅ 직렬화 가능한 Map으로 감싸서 반환
+        return ResponseEntity.ok(Map.of(
+                "content", pageResult.getContent(),
+                "page", pageResult.getNumber(),
+                "size", pageResult.getSize(),
+                "totalElements", pageResult.getTotalElements(),
+                "totalPages", pageResult.getTotalPages()
+        ));
+    }
+
+
+
+
 }
+

--- a/src/main/java/com/waytoearth/dto/response/running/RunningRecordSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/RunningRecordSummaryResponse.java
@@ -3,9 +3,11 @@ package com.waytoearth.dto.response.running;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor; //추가
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor //추가
 public class RunningRecordSummaryResponse {
     @Schema(example = "456")
     private Long id;

--- a/src/main/java/com/waytoearth/entity/RunningRecord.java
+++ b/src/main/java/com/waytoearth/entity/RunningRecord.java
@@ -1,8 +1,7 @@
 package com.waytoearth.entity;
 
-import com.waytoearth.entity.enums.RunningType;
-import com.waytoearth.entity.enums.WeatherCondition;
 import com.waytoearth.entity.enums.RunningStatus;
+import com.waytoearth.entity.enums.RunningType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -72,8 +71,9 @@ public class RunningRecord {
     private Integer calories;
 
     /** 완료 여부 */
-    @Column(name = "is_completed", nullable = false)
+    @Column(name = "is_completed", columnDefinition = "TINYINT(1)", nullable = false) //columnDefinition 변경
     private Boolean isCompleted;
+
 
     /** 시작 시각 */
     @Column(name = "started_at", nullable = false)

--- a/src/main/java/com/waytoearth/service/running/RunningService.java
+++ b/src/main/java/com/waytoearth/service/running/RunningService.java
@@ -1,8 +1,12 @@
 package com.waytoearth.service.running;
 
 import com.waytoearth.dto.request.running.*;
-import com.waytoearth.dto.response.running.*;
+import com.waytoearth.dto.response.running.RunningCompleteResponse;
+import com.waytoearth.dto.response.running.RunningRecordSummaryResponse;
+import com.waytoearth.dto.response.running.RunningStartResponse;
 import com.waytoearth.security.AuthenticatedUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface RunningService {
 
@@ -22,4 +26,6 @@ public interface RunningService {
 
     // 완료 페이지 재조회(경로 포함)
     RunningCompleteResponse getDetail(AuthenticatedUser user, Long recordId);
+
+    Page<RunningRecordSummaryResponse> getRecords(AuthenticatedUser authUser, Pageable pageable);
 }

--- a/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
@@ -1,7 +1,9 @@
 package com.waytoearth.service.running;
 
 import com.waytoearth.dto.request.running.*;
-import com.waytoearth.dto.response.running.*;
+import com.waytoearth.dto.response.running.RunningCompleteResponse;
+import com.waytoearth.dto.response.running.RunningRecordSummaryResponse;
+import com.waytoearth.dto.response.running.RunningStartResponse;
 import com.waytoearth.entity.RunningRecord;
 import com.waytoearth.entity.User;
 import com.waytoearth.entity.enums.RunningStatus;
@@ -11,12 +13,15 @@ import com.waytoearth.repository.RunningRouteRepository;
 import com.waytoearth.repository.UserRepository;
 import com.waytoearth.security.AuthenticatedUser;
 import com.waytoearth.service.emblem.EmblemService;
-import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -111,17 +116,29 @@ public class RunningServiceImpl implements RunningService {
 
     @Override
     public RunningCompleteResponse completeRunning(AuthenticatedUser authUser, RunningCompleteRequest request) {
+        System.out.println("=== completeRunning 시작 ===");
+        System.out.println("SessionId: " + request.getSessionId());
+        System.out.println("UserId: " + authUser.getUserId());
+
         RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
                 .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
 
-        // 권한 검증 추가
+        System.out.println("찾은 기록 ID: " + record.getId());
+        System.out.println("기록 소유자 ID: " + record.getUser().getId());
+
+        // 권한 검증
         if (!record.getUser().getId().equals(authUser.getUserId())) {
             throw new IllegalArgumentException("해당 세션에 대한 권한이 없습니다.");
         }
 
         BigDecimal distanceKm = BigDecimal.valueOf(request.getDistanceMeters() / 1000.0);
+        System.out.println("거리(km): " + distanceKm);
 
-        // 도메인 메서드 사용: complete(...)
+        // 완료 처리 전 상태
+        System.out.println("완료 처리 전 - isCompleted: " + record.getIsCompleted());
+        System.out.println("완료 처리 전 - status: " + record.getStatus());
+
+        // 도메인 메서드 사용
         record.complete(
                 distanceKm,
                 request.getDurationSeconds(),
@@ -129,6 +146,10 @@ public class RunningServiceImpl implements RunningService {
                 request.getCalories(),
                 LocalDateTime.now()
         );
+
+        // 완료 처리 후 상태
+        System.out.println("완료 처리 후 - isCompleted: " + record.getIsCompleted());
+        System.out.println("완료 처리 후 - status: " + record.getStatus());
 
         // 경로 전체 추가
         if (request.getRoutePoints() != null) {
@@ -143,29 +164,35 @@ public class RunningServiceImpl implements RunningService {
         userRepository.save(user);
 
         // 저장 후 응답 구성
-        runningRecordRepository.save(record);
+        RunningRecord savedRecord = runningRecordRepository.save(record);
+        System.out.println("저장된 기록 ID: " + savedRecord.getId());
+        System.out.println("저장된 기록 완료상태: " + savedRecord.getIsCompleted());
+
+        // ✅ 강제 flush
+        runningRecordRepository.flush();
+        System.out.println("flush 완료");
 
         // 엠블럼 자동 지급
         var awardResult = emblemService.scanAndAward(user.getId(), "DISTANCE");
 
+        System.out.println("=== completeRunning 완료 ===");
+
         return new RunningCompleteResponse(
-                record.getId(),
-                record.getTitle(), // 제목은 PATCH로 수정 가능
-                record.getDistance() != null ? record.getDistance().doubleValue() : 0.0,
-                formatPace(record.getAveragePaceSeconds()),
-                record.getCalories(),
-                record.getStartedAt() != null ? record.getStartedAt().toString() : null,
-                record.getEndedAt() != null ? record.getEndedAt().toString() : null,
-                record.getRoutes().stream()
+                savedRecord.getId(),
+                savedRecord.getTitle(),
+                savedRecord.getDistance() != null ? savedRecord.getDistance().doubleValue() : 0.0,
+                formatPace(savedRecord.getAveragePaceSeconds()),
+                savedRecord.getCalories(),
+                savedRecord.getStartedAt() != null ? savedRecord.getStartedAt().toString() : null,
+                savedRecord.getEndedAt() != null ? savedRecord.getEndedAt().toString() : null,
+                savedRecord.getRoutes().stream()
                         .map(rt -> new RunningCompleteResponse.RoutePoint(
                                 rt.getLatitude(), rt.getLongitude(), rt.getSequence()
                         ))
                         .collect(Collectors.toList()),
                 awardResult
         );
-
     }
-
     @Override
     public void updateTitle(AuthenticatedUser authUser, Long recordId, RunningTitleUpdateRequest request) {
         RunningRecord record = runningRecordRepository.findById(recordId)
@@ -216,4 +243,60 @@ public class RunningServiceImpl implements RunningService {
         int s = paceSeconds % 60;
         return String.format("%02d:%02d", m, s);
     }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<RunningRecordSummaryResponse> getRecords(AuthenticatedUser authUser, Pageable pageable) {
+        System.out.println("=== getRecords 시작 ===");
+        System.out.println("요청 사용자 ID: " + authUser.getUserId());
+
+        User user = userRepository.findById(authUser.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        System.out.println("찾은 사용자: " + user.getId());
+
+        // ✅ 디버깅: 해당 사용자의 모든 기록 확인
+        List<RunningRecord> allRecords = runningRecordRepository.findAll().stream()
+                .filter(r -> r.getUser().getId().equals(user.getId()))
+                .collect(Collectors.toList());
+
+        System.out.println("해당 사용자의 전체 기록 수: " + allRecords.size());
+        allRecords.forEach(r -> {
+            System.out.println("- 기록 ID: " + r.getId() +
+                    ", SessionId: " + r.getSessionId() +
+                    ", 완료여부: " + r.getIsCompleted() +
+                    ", 상태: " + r.getStatus() +
+                    ", 거리: " + r.getDistance());
+        });
+
+        // ✅ 완료된 기록만 필터링해서 확인
+        long completedCount = allRecords.stream()
+                .filter(r -> Boolean.TRUE.equals(r.getIsCompleted()))
+                .count();
+
+        System.out.println("완료된 기록 수: " + completedCount);
+
+        Page<RunningRecord> pageResult = runningRecordRepository
+                .findByUserAndIsCompletedTrueOrderByStartedAtDesc(user, pageable);
+
+        System.out.println("페이지 결과 - 총 요소: " + pageResult.getTotalElements());
+        System.out.println("페이지 결과 - 현재 페이지 크기: " + pageResult.getContent().size());
+
+        Page<RunningRecordSummaryResponse> result = pageResult.map(r -> {
+            System.out.println("매핑 중인 기록: " + r.getId());
+            return new RunningRecordSummaryResponse(
+                    r.getId(),
+                    r.getTitle(),
+                    r.getDistance() != null ? r.getDistance().doubleValue() : 0.0,
+                    r.getDuration() != null ? r.getDuration() : 0,
+                    formatPace(r.getAveragePaceSeconds()),
+                    r.getCalories() != null ? r.getCalories() : 0,
+                    r.getStartedAt() != null ? r.getStartedAt().toString() : null
+            );
+        });
+
+        System.out.println("=== getRecords 완료 ===");
+        return result;
+    }
+
 }


### PR DESCRIPTION
##  연관 이슈

> #23 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [x] 기능 추가
* [ ] 기능 삭제
* [x] 버그 수정
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

###  PR 내용 요약

* **러닝 기록 목록 조회 API 개선 (`/v1/running/records`)**

  * `RunningRecordSummaryResponse`에 `@NoArgsConstructor` 추가 → 직렬화 오류 방지
  * DTO 매핑 시 `distance`, `duration`, `calories`, `startedAt` 등 `null` 안전 처리
  * 완료된 러닝 기록만 필터링 (`isCompleted = true`) 하여 반환하도록 보장
  * 정렬 조건: `startedAt` 기준 최신순

* **러닝 상세 조회 API 연결**
  * `GET /v1/running/{recordId}` → 프론트에서 단일 기록 상세 페이지에서 사용 가능
  * 응답에 `routePoints`(위경도 경로), `거리/시간/페이스/칼로리` 포함
* **프론트 연동 시나리오**
  * 기록 목록 클릭 → `/v1/running/{recordId}` 호출 → 지도 및 상세 정보 표시 가능

* **엔티티 (`RunningRecord`) 개선**

  * `isCompleted` 컬럼을 `TINYINT(1)`으로 명시 → MySQL/MariaDB에서 boolean 매핑 안정화
  * `complete()` 메서드에서 상태 변경 및 안전한 값 세팅 로직 보강

---

###  테스트 결과

* 사용자별 러닝 기록 조회 시 **완료된 기록만 반환** 확인
* JSON 응답 직렬화 시 DTO 매핑 오류 없이 정상 출력 확인
* 페이징(`page`, `size`) 요청값에 따라 올바른 페이지 결과 반환 확인

---

##  리뷰 요구사항 (선택)

