### PR TITLE
가상 러닝 API 추가 및 개선

### DIFF
--- a/src/main/java/com/waytoearth/config/SwaggerConfig.java
+++ b/src/main/java/com/waytoearth/config/SwaggerConfig.java
@@ -111,4 +111,39 @@ public class SwaggerConfig {
                 .pathsToMatch("/v1/emblems/**")
                 .build();
     }
+
+
+
+    @Bean
+    public GroupedOpenApi themeCourseApi() {
+        return GroupedOpenApi.builder()
+                .group("11. 테마 코스 API")
+                .pathsToMatch("/v1/theme-courses/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi customCourseApi() {
+        return GroupedOpenApi.builder()
+                .group("12. 커스텀 코스 API")
+                .pathsToMatch("/v1/custom-courses/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi courseSegmentApi() {
+        return GroupedOpenApi.builder()
+                .group("13. 코스 세그먼트 API")
+                .pathsToMatch("/v1/course-segments/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi userVirtualCourseApi() {
+        return GroupedOpenApi.builder()
+                .group("14. 사용자 가상 코스 API")
+                .pathsToMatch("/v1/user-virtual-courses/**")
+                .build();
+    }
+
 }

--- a/src/main/java/com/waytoearth/controller/v1/RunningController.java
+++ b/src/main/java/com/waytoearth/controller/v1/RunningController.java
@@ -3,13 +3,18 @@ package com.waytoearth.controller.v1;
 
 import com.waytoearth.dto.request.running.*;
 import com.waytoearth.dto.response.running.*;
-import com.waytoearth.service.running.RunningService;
 import com.waytoearth.security.AuthUser;
 import com.waytoearth.security.AuthenticatedUser;
+import com.waytoearth.service.running.RunningService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/v1/running")
@@ -78,4 +83,29 @@ public class RunningController {
             @PathVariable Long recordId) {
         return ResponseEntity.ok(runningService.getDetail(user, recordId));
     }
+
+    @Operation(summary = "러닝 기록 목록 조회 (페이징)")
+    @GetMapping("/records")
+    public ResponseEntity<?> getRecords(
+            @AuthUser AuthenticatedUser user,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<RunningRecordSummaryResponse> pageResult = runningService.getRecords(user, pageable);
+
+        // ✅ 직렬화 가능한 Map으로 감싸서 반환
+        return ResponseEntity.ok(Map.of(
+                "content", pageResult.getContent(),
+                "page", pageResult.getNumber(),
+                "size", pageResult.getSize(),
+                "totalElements", pageResult.getTotalElements(),
+                "totalPages", pageResult.getTotalPages()
+        ));
+    }
+
+
+
+
 }
+

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CourseSegmentController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CourseSegmentController.java
@@ -15,42 +15,66 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/course-segments")
+@RequestMapping("/v1/course-segments")
 @RequiredArgsConstructor
 @Tag(name = "CourseSegment", description = "코스 세그먼트 관리 API")
 public class CourseSegmentController {
 
     private final CourseSegmentService courseSegmentService;
 
-    @Operation(summary = "세그먼트 추가", description = "특정 코스에 새로운 세그먼트를 추가합니다.")
+    // ✅ 테마 코스 세그먼트 추가
+    @Operation(summary = "테마 코스에 세그먼트 추가", description = "특정 테마 코스에 새로운 세그먼트를 추가합니다.")
     @ApiResponse(responseCode = "200", description = "추가 성공")
-    @PostMapping("/{courseId}")
-    public ResponseEntity<CourseSegmentDetailResponse> addSegment(
-            @PathVariable Long courseId,
+    @PostMapping("/theme/{themeCourseId}")
+    public ResponseEntity<CourseSegmentDetailResponse> addSegmentToTheme(
+            @PathVariable Long themeCourseId,
             @Valid @RequestBody CourseSegmentCreateRequest request
     ) {
-        return ResponseEntity.ok(courseSegmentService.addSegment(courseId, request));
+        return ResponseEntity.ok(courseSegmentService.addSegmentToThemeCourse(themeCourseId, request));
     }
 
-    @Operation(summary = "세그먼트 목록 조회", description = "특정 코스에 포함된 모든 세그먼트를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "조회 성공")
-    @GetMapping("/{courseId}")
-    public ResponseEntity<List<CourseSegmentSummaryResponse>> getSegments(
-            @PathVariable Long courseId
+    // ✅ 커스텀 코스 세그먼트 추가
+    @Operation(summary = "커스텀 코스에 세그먼트 추가", description = "특정 커스텀 코스에 새로운 세그먼트를 추가합니다.")
+    @ApiResponse(responseCode = "200", description = "추가 성공")
+    @PostMapping("/custom/{customCourseId}")
+    public ResponseEntity<CourseSegmentDetailResponse> addSegmentToCustom(
+            @PathVariable Long customCourseId,
+            @Valid @RequestBody CourseSegmentCreateRequest request
     ) {
-        return ResponseEntity.ok(courseSegmentService.getSegments(courseId));
+        return ResponseEntity.ok(courseSegmentService.addSegmentToCustomCourse(customCourseId, request));
     }
 
+    // ✅ 테마 코스 세그먼트 목록 조회
+    @Operation(summary = "테마 코스 세그먼트 목록 조회", description = "특정 테마 코스에 포함된 모든 세그먼트를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/theme/{themeCourseId}")
+    public ResponseEntity<List<CourseSegmentSummaryResponse>> getSegmentsByTheme(
+            @PathVariable Long themeCourseId
+    ) {
+        return ResponseEntity.ok(courseSegmentService.getSegmentsByThemeCourse(themeCourseId));
+    }
+
+    // ✅ 커스텀 코스 세그먼트 목록 조회
+    @Operation(summary = "커스텀 코스 세그먼트 목록 조회", description = "특정 커스텀 코스에 포함된 모든 세그먼트를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/custom/{customCourseId}")
+    public ResponseEntity<List<CourseSegmentSummaryResponse>> getSegmentsByCustom(
+            @PathVariable Long customCourseId
+    ) {
+        return ResponseEntity.ok(courseSegmentService.getSegmentsByCustomCourse(customCourseId));
+    }
+
+    // ✅ 세그먼트 상세 조회
     @Operation(summary = "세그먼트 상세 조회", description = "특정 세그먼트의 상세 정보를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    @ApiResponse(responseCode = "404", description = "세그먼트를 찾을 수 없음")
-    @GetMapping("/detail/{segmentId}")
+    @GetMapping("/{segmentId}")
     public ResponseEntity<CourseSegmentDetailResponse> getSegmentDetail(
             @PathVariable Long segmentId
     ) {
         return ResponseEntity.ok(courseSegmentService.getSegmentDetail(segmentId));
     }
 
+    // ✅ 세그먼트 삭제
     @Operation(summary = "세그먼트 삭제", description = "특정 세그먼트를 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "삭제 성공")
     @DeleteMapping("/{segmentId}")

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CourseSegmentController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CourseSegmentController.java
@@ -1,0 +1,4 @@
+package com.waytoearth.controller.v1.VirtualRunning;
+
+public class CourseSegmentController {
+}

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CourseSegmentController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CourseSegmentController.java
@@ -1,4 +1,63 @@
 package com.waytoearth.controller.v1.VirtualRunning;
 
+import com.waytoearth.dto.request.Virtual.CourseSegmentCreateRequest;
+import com.waytoearth.dto.response.Virtual.CourseSegmentDetailResponse;
+import com.waytoearth.dto.response.Virtual.CourseSegmentSummaryResponse;
+import com.waytoearth.service.VirtualRunning.CourseSegmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/course-segments")
+@RequiredArgsConstructor
+@Tag(name = "CourseSegment", description = "코스 세그먼트 관리 API")
 public class CourseSegmentController {
+
+    private final CourseSegmentService courseSegmentService;
+
+    @Operation(summary = "세그먼트 추가", description = "특정 코스에 새로운 세그먼트를 추가합니다.")
+    @ApiResponse(responseCode = "200", description = "추가 성공")
+    @PostMapping("/{courseId}")
+    public ResponseEntity<CourseSegmentDetailResponse> addSegment(
+            @PathVariable Long courseId,
+            @Valid @RequestBody CourseSegmentCreateRequest request
+    ) {
+        return ResponseEntity.ok(courseSegmentService.addSegment(courseId, request));
+    }
+
+    @Operation(summary = "세그먼트 목록 조회", description = "특정 코스에 포함된 모든 세그먼트를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/{courseId}")
+    public ResponseEntity<List<CourseSegmentSummaryResponse>> getSegments(
+            @PathVariable Long courseId
+    ) {
+        return ResponseEntity.ok(courseSegmentService.getSegments(courseId));
+    }
+
+    @Operation(summary = "세그먼트 상세 조회", description = "특정 세그먼트의 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "404", description = "세그먼트를 찾을 수 없음")
+    @GetMapping("/detail/{segmentId}")
+    public ResponseEntity<CourseSegmentDetailResponse> getSegmentDetail(
+            @PathVariable Long segmentId
+    ) {
+        return ResponseEntity.ok(courseSegmentService.getSegmentDetail(segmentId));
+    }
+
+    @Operation(summary = "세그먼트 삭제", description = "특정 세그먼트를 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "삭제 성공")
+    @DeleteMapping("/{segmentId}")
+    public ResponseEntity<Void> deleteSegment(
+            @PathVariable Long segmentId
+    ) {
+        courseSegmentService.deleteSegment(segmentId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CustomCourseController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CustomCourseController.java
@@ -1,4 +1,62 @@
 package com.waytoearth.controller.v1.VirtualRunning;
 
+import com.waytoearth.dto.request.Virtual.CustomCourseCreateRequest;
+import com.waytoearth.dto.response.Virtual.CustomCourseDetailResponse;
+import com.waytoearth.dto.response.Virtual.CustomCourseSummaryResponse;
+import com.waytoearth.service.VirtualRunning.CustomCourseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/custom-courses")
+@RequiredArgsConstructor
+@Tag(name = "CustomCourse", description = "사용자 커스텀 코스 API")
 public class CustomCourseController {
+
+    private final CustomCourseService customCourseService;
+
+    @Operation(summary = "커스텀 코스 생성", description = "사용자가 직접 코스를 생성합니다.")
+    @ApiResponse(responseCode = "200", description = "생성 성공")
+    @PostMapping
+    public ResponseEntity<CustomCourseDetailResponse> createCourse(
+            @Valid @RequestBody CustomCourseCreateRequest request
+    ) {
+        return ResponseEntity.ok(customCourseService.createCourse(request));
+    }
+
+    @Operation(summary = "사용자 커스텀 코스 목록 조회", description = "특정 사용자가 등록한 모든 커스텀 코스를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<CustomCourseSummaryResponse>> getUserCourses(
+            @PathVariable Long userId
+    ) {
+        return ResponseEntity.ok(customCourseService.getUserCourses(userId));
+    }
+
+    @Operation(summary = "커스텀 코스 상세 조회", description = "특정 커스텀 코스의 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/{courseId}")
+    public ResponseEntity<CustomCourseDetailResponse> getCourseDetail(
+            @PathVariable Long courseId
+    ) {
+        return ResponseEntity.ok(customCourseService.getCourseDetail(courseId));
+    }
+
+    @Operation(summary = "커스텀 코스 삭제", description = "사용자가 등록한 커스텀 코스를 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "삭제 성공")
+    @DeleteMapping("/{courseId}/user/{userId}")
+    public ResponseEntity<Void> deleteCourse(
+            @PathVariable Long courseId,
+            @PathVariable Long userId
+    ) {
+        customCourseService.deleteCourse(courseId, userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CustomCourseController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CustomCourseController.java
@@ -1,0 +1,4 @@
+package com.waytoearth.controller.v1.VirtualRunning;
+
+public class CustomCourseController {
+}

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CustomCourseController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/CustomCourseController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/custom-courses")
+@RequestMapping("/v1/custom-courses")
 @RequiredArgsConstructor
 @Tag(name = "CustomCourse", description = "사용자 커스텀 코스 API")
 public class CustomCourseController {

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/ThemeCourseController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/ThemeCourseController.java
@@ -1,4 +1,42 @@
 package com.waytoearth.controller.v1.VirtualRunning;
 
+import com.waytoearth.dto.response.Virtual.ThemeCourseDetailResponse;
+import com.waytoearth.dto.response.Virtual.ThemeCourseSummaryResponse;
+import com.waytoearth.service.VirtualRunning.ThemeCourseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/theme-courses")
+@RequiredArgsConstructor
+@Tag(name = "ThemeCourse", description = "운영자 제공 테마 코스 API")
 public class ThemeCourseController {
+
+    private final ThemeCourseService themeCourseService;
+
+    @Operation(summary = "테마 코스 목록 조회", description = "운영자가 제공하는 테마 코스 전체 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping
+    public ResponseEntity<List<ThemeCourseSummaryResponse>> getThemeCourses() {
+        return ResponseEntity.ok(themeCourseService.getThemeCourses());
+    }
+
+    @Operation(summary = "테마 코스 상세 조회", description = "특정 테마 코스의 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "404", description = "코스를 찾을 수 없음")
+    @GetMapping("/{courseId}")
+    public ResponseEntity<ThemeCourseDetailResponse> getThemeCourseDetail(
+            @PathVariable Long courseId
+    ) {
+        return ResponseEntity.ok(themeCourseService.getThemeCourseDetail(courseId));
+    }
 }

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/ThemeCourseController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/ThemeCourseController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/theme-courses")
+@RequestMapping("/v1/theme-courses")
 @RequiredArgsConstructor
 @Tag(name = "ThemeCourse", description = "운영자 제공 테마 코스 API")
 public class ThemeCourseController {

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/ThemeCourseController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/ThemeCourseController.java
@@ -1,0 +1,4 @@
+package com.waytoearth.controller.v1.VirtualRunning;
+
+public class ThemeCourseController {
+}

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/UserVirtualCourseController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/UserVirtualCourseController.java
@@ -1,5 +1,6 @@
 package com.waytoearth.controller.v1.VirtualRunning;
 
+import com.waytoearth.dto.request.Virtual.UserVirtualCourseCreateRequest;
 import com.waytoearth.dto.request.Virtual.VirtualCourseProgressUpdateRequest;
 import com.waytoearth.dto.response.Virtual.*;
 import com.waytoearth.service.VirtualRunning.SegmentEmblemService;
@@ -85,4 +86,15 @@ public class UserVirtualCourseController {
     ) {
         return ResponseEntity.ok(segmentEmblemService.checkEmblem(userVirtualCourseId, segmentId, distance));
     }
+
+
+    @Operation(summary = "사용자 가상 코스 등록", description = "사용자가 특정 코스를 선택하여 가상 러닝 코스를 시작합니다.")
+    @ApiResponse(responseCode = "200", description = "등록 성공")
+    @PostMapping
+    public ResponseEntity<UserVirtualCourseResponse> createUserVirtualCourse(
+            @Valid @RequestBody UserVirtualCourseCreateRequest request
+    ) {
+        return ResponseEntity.ok(userVirtualCourseService.createUserVirtualCourse(request));
+    }
+
 }

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/UserVirtualCourseController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/UserVirtualCourseController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/user-courses")
+@RequestMapping("/v1/user-virtual-courses")
 @RequiredArgsConstructor
 @Tag(name = "UserVirtualCourse", description = "사용자 가상 코스 진행 API")
 public class UserVirtualCourseController {

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/UserVirtualCourseController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/UserVirtualCourseController.java
@@ -1,4 +1,88 @@
 package com.waytoearth.controller.v1.VirtualRunning;
 
+import com.waytoearth.dto.request.Virtual.VirtualCourseProgressUpdateRequest;
+import com.waytoearth.dto.response.Virtual.*;
+import com.waytoearth.service.VirtualRunning.SegmentEmblemService;
+import com.waytoearth.service.VirtualRunning.SegmentLandmarkService;
+import com.waytoearth.service.VirtualRunning.SegmentWeatherService;
+import com.waytoearth.service.VirtualRunning.UserVirtualCourseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/user-courses")
+@RequiredArgsConstructor
+@Tag(name = "UserVirtualCourse", description = "사용자 가상 코스 진행 API")
 public class UserVirtualCourseController {
+
+    private final UserVirtualCourseService userVirtualCourseService;
+    private final SegmentWeatherService segmentWeatherService;
+    private final SegmentLandmarkService segmentLandmarkService;
+    private final SegmentEmblemService segmentEmblemService;
+
+    @Operation(summary = "코스 진행률 업데이트", description = "사용자의 러닝 기록을 반영하여 진행률을 업데이트합니다.")
+    @ApiResponse(responseCode = "200", description = "업데이트 성공")
+    @PostMapping("/{userVirtualCourseId}/progress")
+    public ResponseEntity<VirtualCourseProgressResponse> updateProgress(
+            @PathVariable Long userVirtualCourseId,
+            @Valid @RequestBody VirtualCourseProgressUpdateRequest request
+    ) {
+        return ResponseEntity.ok(userVirtualCourseService.updateProgress(userVirtualCourseId, request));
+    }
+
+    @Operation(summary = "코스 전체 진행률 조회", description = "사용자의 전체 가상 코스 진행률을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/{userVirtualCourseId}/progress")
+    public ResponseEntity<VirtualCourseProgressResponse> getProgress(
+            @PathVariable Long userVirtualCourseId
+    ) {
+        return ResponseEntity.ok(userVirtualCourseService.getProgress(userVirtualCourseId));
+    }
+
+    @Operation(summary = "세그먼트 진행률 조회", description = "사용자의 특정 가상 코스에서 세그먼트별 진행률을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/{userVirtualCourseId}/segments")
+    public ResponseEntity<List<SegmentProgressResponse>> getSegmentProgress(
+            @PathVariable Long userVirtualCourseId
+    ) {
+        return ResponseEntity.ok(userVirtualCourseService.getSegmentProgress(userVirtualCourseId));
+    }
+
+    @Operation(summary = "세그먼트 날씨 조회", description = "특정 세그먼트의 날씨 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/{userVirtualCourseId}/segments/{segmentId}/weather")
+    public ResponseEntity<SegmentWeatherResponse> getWeather(
+            @PathVariable Long userVirtualCourseId,
+            @PathVariable Long segmentId
+    ) {
+        return ResponseEntity.ok(segmentWeatherService.getWeather(segmentId));
+    }
+
+    @Operation(summary = "세그먼트 랜드마크 조회", description = "특정 세그먼트의 랜드마크 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/{userVirtualCourseId}/segments/{segmentId}/landmarks")
+    public ResponseEntity<List<SegmentLandmarkResponse>> getLandmarks(
+            @PathVariable Long userVirtualCourseId,
+            @PathVariable Long segmentId
+    ) {
+        return ResponseEntity.ok(segmentLandmarkService.getLandmarks(segmentId));
+    }
+
+    @Operation(summary = "세그먼트 엠블럼 확인", description = "특정 세그먼트에서 달성한 엠블럼을 확인합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/{userVirtualCourseId}/segments/{segmentId}/emblems")
+    public ResponseEntity<SegmentEmblemResponse> getEmblem(
+            @PathVariable Long userVirtualCourseId,
+            @PathVariable Long segmentId,
+            @RequestParam Double distance
+    ) {
+        return ResponseEntity.ok(segmentEmblemService.checkEmblem(userVirtualCourseId, segmentId, distance));
+    }
 }

--- a/src/main/java/com/waytoearth/controller/v1/VirtualRunning/UserVirtualCourseController.java
+++ b/src/main/java/com/waytoearth/controller/v1/VirtualRunning/UserVirtualCourseController.java
@@ -1,0 +1,4 @@
+package com.waytoearth.controller.v1.VirtualRunning;
+
+public class UserVirtualCourseController {
+}

--- a/src/main/java/com/waytoearth/dto/request/Virtual/CourseSegmentCreateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/Virtual/CourseSegmentCreateRequest.java
@@ -1,4 +1,41 @@
 package com.waytoearth.dto.request.Virtual;
 
+import com.waytoearth.entity.enums.SegmentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "세그먼트 생성 요청 DTO")
 public class CourseSegmentCreateRequest {
+
+    @NotNull
+    @Schema(description = "세그먼트 타입", example = "DOMESTIC")
+    private SegmentType type;
+
+    @NotNull
+    @Schema(description = "순서", example = "1")
+    private Integer orderIndex;
+
+    @NotNull
+    @Schema(description = "시작 위도", example = "37.5665")
+    private Double startLat;
+
+    @NotNull
+    @Schema(description = "시작 경도", example = "126.9780")
+    private Double startLng;
+
+    @NotNull
+    @Schema(description = "종료 위도", example = "35.1796")
+    private Double endLat;
+
+    @NotNull
+    @Schema(description = "종료 경도", example = "129.0756")
+    private Double endLng;
+
+    @NotNull
+    @Schema(description = "거리 (km)", example = "45.7")
+    private Double distanceKm;
 }

--- a/src/main/java/com/waytoearth/dto/request/Virtual/CourseSegmentCreateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/Virtual/CourseSegmentCreateRequest.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.request.Virtual;
+
+public class CourseSegmentCreateRequest {
+}

--- a/src/main/java/com/waytoearth/dto/request/Virtual/CustomCourseCreateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/Virtual/CustomCourseCreateRequest.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.request.Virtual;
+
+public class CustomCourseCreateRequest {
+}

--- a/src/main/java/com/waytoearth/dto/request/Virtual/CustomCourseCreateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/Virtual/CustomCourseCreateRequest.java
@@ -1,4 +1,27 @@
 package com.waytoearth.dto.request.Virtual;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Schema(description = "커스텀 코스 생성 요청 DTO")
 public class CustomCourseCreateRequest {
+
+    @NotNull
+    @Schema(description = "사용자 ID", example = "42")
+    private Long userId;
+
+    @NotBlank
+    @Schema(description = "코스 제목", example = "한강 러닝 코스")
+    private String title;
+
+    @NotNull
+    @Schema(description = "세그먼트 배열")
+    private List<CourseSegmentCreateRequest> segments;
 }

--- a/src/main/java/com/waytoearth/dto/request/Virtual/UserVirtualCourseCreateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/Virtual/UserVirtualCourseCreateRequest.java
@@ -1,0 +1,21 @@
+package com.waytoearth.dto.request.Virtual;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "사용자 가상 코스 등록 요청 DTO")
+public record UserVirtualCourseCreateRequest(
+
+        @NotNull
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+
+        @NotNull
+        @Schema(description = "코스 ID (ThemeCourse 또는 CustomCourse)", example = "10")
+        Long courseId,
+
+        @NotNull
+        @Schema(description = "코스 타입", example = "CUSTOM")
+        String courseType
+) {}

--- a/src/main/java/com/waytoearth/dto/request/Virtual/VirtualCourseProgressUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/Virtual/VirtualCourseProgressUpdateRequest.java
@@ -1,4 +1,20 @@
 package com.waytoearth.dto.request.Virtual;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "가상 코스 진행률 업데이트 요청 DTO")
 public class VirtualCourseProgressUpdateRequest {
+
+    @NotNull
+    @Schema(description = "세그먼트 ID", example = "100")
+    private Long segmentId;
+
+    @NotNull
+    @Schema(description = "추가 거리 (km)", example = "2.5")
+    private Double distanceKm;
 }

--- a/src/main/java/com/waytoearth/dto/request/Virtual/VirtualCourseProgressUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/Virtual/VirtualCourseProgressUpdateRequest.java
@@ -17,4 +17,33 @@ public class VirtualCourseProgressUpdateRequest {
     @NotNull
     @Schema(description = "추가 거리 (km)", example = "2.5")
     private Double distanceKm;
+
+    @Schema(description = "운동 시간(초)", example = "1800")
+    private Integer durationSeconds;
+
+    @Schema(description = "평균 페이스(초/km)", example = "360")
+    private Integer averagePaceSeconds;
+
+    @Schema(description = "칼로리(kcal)", example = "350")
+    private Integer calories;
+
+    @Schema(description = "세션 ID", example = "a1b2c3d4-5678-90ef")
+    private String sessionId;
+
+    @Schema(description = "현재 위치 좌표")
+    private RoutePoint currentPoint;
+
+    @Getter
+    @Setter
+    @Schema(description = "경로 좌표")
+    public static class RoutePoint {
+        @Schema(description = "위도", example = "37.5665")
+        private Double latitude;
+
+        @Schema(description = "경도", example = "126.9780")
+        private Double longitude;
+
+        @Schema(description = "순서", example = "10")
+        private Integer sequence;
+    }
 }

--- a/src/main/java/com/waytoearth/dto/request/Virtual/VirtualCourseProgressUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/Virtual/VirtualCourseProgressUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.request.Virtual;
+
+public class VirtualCourseProgressUpdateRequest {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/CourseSegmentDetailResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/CourseSegmentDetailResponse.java
@@ -1,4 +1,14 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class CourseSegmentDetailResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "세그먼트 상세 응답 DTO")
+public record CourseSegmentDetailResponse(
+        @Schema(description = "세그먼트 ID", example = "100") Long id,
+        @Schema(description = "타입", example = "DOMESTIC") String type,
+        @Schema(description = "시작 위도", example = "37.5665") Double startLat,
+        @Schema(description = "시작 경도", example = "126.9780") Double startLng,
+        @Schema(description = "종료 위도", example = "35.1796") Double endLat,
+        @Schema(description = "종료 경도", example = "129.0756") Double endLng,
+        @Schema(description = "거리 (km)", example = "45.7") Double distanceKm
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/CourseSegmentDetailResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/CourseSegmentDetailResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class CourseSegmentDetailResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/CourseSegmentSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/CourseSegmentSummaryResponse.java
@@ -1,4 +1,10 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class CourseSegmentSummaryResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "세그먼트 요약 응답 DTO")
+public record CourseSegmentSummaryResponse(
+        @Schema(description = "세그먼트 ID", example = "100") Long id,
+        @Schema(description = "순서", example = "1") Integer orderIndex,
+        @Schema(description = "거리 (km)", example = "45.7") Double distanceKm
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/CourseSegmentSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/CourseSegmentSummaryResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class CourseSegmentSummaryResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/CustomCourseDetailResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/CustomCourseDetailResponse.java
@@ -1,4 +1,13 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class CustomCourseDetailResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "사용자 커스텀 코스 상세 응답 DTO")
+public record CustomCourseDetailResponse(
+        @Schema(description = "코스 ID", example = "10") Long id,
+        @Schema(description = "제목", example = "한강 러닝 코스") String title,
+        @Schema(description = "총 거리 (km)", example = "12.3") Double totalDistanceKm,
+        @Schema(description = "세그먼트 목록") List<CourseSegmentDetailResponse> segments
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/CustomCourseDetailResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/CustomCourseDetailResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class CustomCourseDetailResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/CustomCourseSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/CustomCourseSummaryResponse.java
@@ -1,4 +1,10 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class CustomCourseSummaryResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 커스텀 코스 목록 응답 DTO")
+public record CustomCourseSummaryResponse(
+        @Schema(description = "코스 ID", example = "10") Long id,
+        @Schema(description = "제목", example = "한강 러닝 코스") String title,
+        @Schema(description = "총 거리 (km)", example = "12.3") Double totalDistanceKm
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/CustomCourseSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/CustomCourseSummaryResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class CustomCourseSummaryResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/SegmentEmblemResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/SegmentEmblemResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class SegmentEmblemResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/SegmentEmblemResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/SegmentEmblemResponse.java
@@ -1,4 +1,10 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class SegmentEmblemResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "세그먼트 엠블럼 응답 DTO")
+public record SegmentEmblemResponse(
+        @Schema(description = "세그먼트 ID", example = "100") Long segmentId,
+        @Schema(description = "엠블럼 이름", example = "10km 달성!") String name,
+        @Schema(description = "엠블럼 코드", example = "EMBLEM_10K") String code
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/SegmentLandmarkResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/SegmentLandmarkResponse.java
@@ -1,4 +1,13 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class SegmentLandmarkResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "세그먼트 랜드마크 응답 DTO")
+public record SegmentLandmarkResponse(
+        @Schema(description = "랜드마크 ID", example = "501") Long id,
+        @Schema(description = "이름", example = "남산타워") String name,
+        @Schema(description = "위도", example = "37.5512") Double latitude,
+        @Schema(description = "경도", example = "126.9882") Double longitude,
+        @Schema(description = "사진 URL") String photoUrl,
+        @Schema(description = "설명", example = "서울의 대표적인 전망 명소") String description
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/SegmentLandmarkResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/SegmentLandmarkResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class SegmentLandmarkResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/SegmentProgressResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/SegmentProgressResponse.java
@@ -1,4 +1,10 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class SegmentProgressResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "세그먼트 진행률 응답 DTO")
+public record SegmentProgressResponse(
+        @Schema(description = "세그먼트 ID", example = "100") Long segmentId,
+        @Schema(description = "세그먼트 누적 거리 (km)", example = "15.2") Double distanceAccumulated,
+        @Schema(description = "상태", example = "ACTIVE") String status
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/SegmentProgressResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/SegmentProgressResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class SegmentProgressResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/SegmentWeatherResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/SegmentWeatherResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class SegmentWeatherResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/SegmentWeatherResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/SegmentWeatherResponse.java
@@ -1,4 +1,11 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class SegmentWeatherResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "세그먼트 날씨 응답 DTO")
+public record SegmentWeatherResponse(
+        @Schema(description = "세그먼트 ID", example = "100") Long segmentId,
+        @Schema(description = "날씨 상태", example = "맑음") String condition,
+        @Schema(description = "기온 (℃)", example = "26.5") Double temperature,
+        @Schema(description = "풍속 (m/s)", example = "2.3") Double windSpeed
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/ThemeCourseDetailResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/ThemeCourseDetailResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class ThemeCourseDetailResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/ThemeCourseDetailResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/ThemeCourseDetailResponse.java
@@ -1,4 +1,14 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class ThemeCourseDetailResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "테마 코스 상세 응답 DTO")
+public record ThemeCourseDetailResponse(
+        @Schema(description = "코스 ID", example = "1") Long id,
+        @Schema(description = "코스 제목", example = "서울 → 부산") String title,
+        @Schema(description = "코스 설명", example = "국내 대표 장거리 러닝 코스") String description,
+        @Schema(description = "총 거리 (km)", example = "350.5") Double totalDistanceKm,
+        @Schema(description = "세그먼트 목록") List<CourseSegmentDetailResponse> segments
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/ThemeCourseSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/ThemeCourseSummaryResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class ThemeCourseSummaryResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/ThemeCourseSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/ThemeCourseSummaryResponse.java
@@ -1,4 +1,10 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class ThemeCourseSummaryResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "테마 코스 목록 응답 DTO")
+public record ThemeCourseSummaryResponse(
+        @Schema(description = "코스 ID", example = "1") Long id,
+        @Schema(description = "코스 제목", example = "서울 → 부산") String title,
+        @Schema(description = "총 거리 (km)", example = "350.5") Double totalDistanceKm
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/UserVirtualCourseResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/UserVirtualCourseResponse.java
@@ -1,0 +1,28 @@
+package com.waytoearth.dto.response.Virtual;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 가상 코스 등록 응답 DTO")
+public record UserVirtualCourseResponse(
+
+        @Schema(description = "등록된 UserVirtualCourse ID", example = "100")
+        Long id,
+
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "코스 ID", example = "10")
+        Long courseId,
+
+        @Schema(description = "코스 타입", example = "CUSTOM")
+        String courseType,
+
+        @Schema(description = "누적 거리 (km)", example = "0.0")
+        Double totalDistanceAccumulated,
+
+        @Schema(description = "진행률 (%)", example = "0.0")
+        Double progressPercent,
+
+        @Schema(description = "코스 진행 상태", example = "ONGOING")
+        String status
+) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/UserVirtualCourseResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/UserVirtualCourseResponse.java
@@ -24,5 +24,8 @@ public record UserVirtualCourseResponse(
         Double progressPercent,
 
         @Schema(description = "코스 진행 상태", example = "ONGOING")
-        String status
+        String status,
+
+        @Schema(description = "러닝 세션 ID (프론트에서 updateProgress 시 사용)", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+        String sessionId
 ) {}

--- a/src/main/java/com/waytoearth/dto/response/Virtual/VirtualCourseProgressResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/VirtualCourseProgressResponse.java
@@ -1,4 +1,12 @@
 package com.waytoearth.dto.response.Virtual;
 
-public class VirtualCourseProgressResponse {
-}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "가상 코스 전체 진행률 응답 DTO")
+public record VirtualCourseProgressResponse(
+        @Schema(description = "진행률 (%)", example = "45.2") Double progressPercent,
+        @Schema(description = "총 누적 거리 (km)", example = "123.4") Double totalDistanceAccumulated,
+        @Schema(description = "상태", example = "ACTIVE") String status
+) {}
+
+

--- a/src/main/java/com/waytoearth/dto/response/Virtual/VirtualCourseProgressResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/Virtual/VirtualCourseProgressResponse.java
@@ -1,0 +1,4 @@
+package com.waytoearth.dto.response.Virtual;
+
+public class VirtualCourseProgressResponse {
+}

--- a/src/main/java/com/waytoearth/dto/response/running/RunningCompleteResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/RunningCompleteResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder   // 추가
+@Builder
 public class RunningCompleteResponse {
 
     @Schema(description = "러닝 기록 ID")
@@ -36,9 +36,15 @@ public class RunningCompleteResponse {
     @Schema(description = "러닝 경로 좌표 목록")
     private List<RoutePoint> routePoints;
 
-    //  추가된 필드
     @Schema(description = "엠블럼 지급 결과")
     private EmblemAwardResult emblemAwardResult;
+
+    // ✅ 추가
+    @Schema(description = "러닝 타입 (SINGLE / VIRTUAL)")
+    private String runningType;
+
+    @Schema(description = "가상 코스 ID (Virtual일 경우만 세팅됨)")
+    private Long virtualCourseId;
 
     @Data
     @NoArgsConstructor

--- a/src/main/java/com/waytoearth/dto/response/running/RunningRecordSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/RunningRecordSummaryResponse.java
@@ -3,12 +3,13 @@ package com.waytoearth.dto.response.running;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor; //추가
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor //추가
+@NoArgsConstructor
 public class RunningRecordSummaryResponse {
+
     @Schema(example = "456")
     private Long id;
 
@@ -29,4 +30,11 @@ public class RunningRecordSummaryResponse {
 
     @Schema(description = "시작 시각(ISO-8601)", example = "2025-08-14T09:30:00")
     private String startedAt;
+
+    // ✅ 추가
+    @Schema(description = "러닝 타입 (SINGLE / VIRTUAL)")
+    private String runningType;
+
+    @Schema(description = "가상 코스 ID (Virtual일 경우만 세팅됨)")
+    private Long virtualCourseId;
 }

--- a/src/main/java/com/waytoearth/dto/response/running/RunningRecordSummaryResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/RunningRecordSummaryResponse.java
@@ -3,9 +3,11 @@ package com.waytoearth.dto.response.running;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor; //추가
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor //추가
 public class RunningRecordSummaryResponse {
     @Schema(example = "456")
     private Long id;

--- a/src/main/java/com/waytoearth/entity/RunningRecord.java
+++ b/src/main/java/com/waytoearth/entity/RunningRecord.java
@@ -25,7 +25,8 @@ import java.util.List;
 @Builder
 public class RunningRecord {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     /** 러닝 소유 사용자 */
@@ -46,10 +47,11 @@ public class RunningRecord {
     @Column(name = "virtual_course_id")
     private Long virtualCourseId;
 
+    /** 러닝 제목 */
     @Column(length = 100)
     private String title;
 
-    /** 러닝 상태*/
+    /** 러닝 상태 */
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
     private RunningStatus status;
@@ -71,9 +73,8 @@ public class RunningRecord {
     private Integer calories;
 
     /** 완료 여부 */
-    @Column(name = "is_completed", columnDefinition = "TINYINT(1)", nullable = false) //columnDefinition 변경
+    @Column(name = "is_completed", columnDefinition = "TINYINT(1)", nullable = false)
     private Boolean isCompleted;
-
 
     /** 시작 시각 */
     @Column(name = "started_at", nullable = false)

--- a/src/main/java/com/waytoearth/entity/RunningRecord.java
+++ b/src/main/java/com/waytoearth/entity/RunningRecord.java
@@ -1,8 +1,7 @@
 package com.waytoearth.entity;
 
-import com.waytoearth.entity.enums.RunningType;
-import com.waytoearth.entity.enums.WeatherCondition;
 import com.waytoearth.entity.enums.RunningStatus;
+import com.waytoearth.entity.enums.RunningType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -72,8 +71,9 @@ public class RunningRecord {
     private Integer calories;
 
     /** 완료 여부 */
-    @Column(name = "is_completed", nullable = false)
+    @Column(name = "is_completed", columnDefinition = "TINYINT(1)", nullable = false) //columnDefinition 변경
     private Boolean isCompleted;
+
 
     /** 시작 시각 */
     @Column(name = "started_at", nullable = false)

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/CourseSegmentEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/CourseSegmentEntity.java
@@ -20,9 +20,15 @@ public class CourseSegmentEntity {
     @Schema(description = "세그먼트 ID", example = "100")
     private Long id;
 
+    // ✅ ThemeCourse와 연결
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id")
-    private CustomCourseEntity course;  // 테마/커스텀 모두 연결 가능 (추후 상속 구조 확장 가능)
+    @JoinColumn(name = "theme_course_id")
+    private ThemeCourseEntity themeCourse;
+
+    // ✅ CustomCourse와 연결
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "custom_course_id")
+    private CustomCourseEntity customCourse;
 
     @Enumerated(EnumType.STRING)
     @Schema(description = "세그먼트 타입", example = "DOMESTIC")

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/CourseSegmentEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/CourseSegmentEntity.java
@@ -1,4 +1,48 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import com.waytoearth.entity.enums.SegmentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "course_segment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "코스를 이루는 세그먼트 엔티티")
 public class CourseSegmentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "세그먼트 ID", example = "100")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id")
+    private CustomCourseEntity course;  // 테마/커스텀 모두 연결 가능 (추후 상속 구조 확장 가능)
+
+    @Enumerated(EnumType.STRING)
+    @Schema(description = "세그먼트 타입", example = "DOMESTIC")
+    private SegmentType type;
+
+    @Schema(description = "세그먼트 순서", example = "1")
+    private Integer orderIndex;
+
+    @Schema(description = "시작 위도", example = "37.5665")
+    private Double startLat;
+
+    @Schema(description = "시작 경도", example = "126.9780")
+    private Double startLng;
+
+    @Schema(description = "종료 위도", example = "35.1796")
+    private Double endLat;
+
+    @Schema(description = "종료 경도", example = "129.0756")
+    private Double endLng;
+
+    @Schema(description = "세그먼트 거리 (km)", example = "45.7")
+    private Double distanceKm;
 }

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/CourseSegmentEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/CourseSegmentEntity.java
@@ -1,0 +1,4 @@
+package com.waytoearth.entity.VirtualRunning;
+
+public class CourseSegmentEntity {
+}

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/CustomCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/CustomCourseEntity.java
@@ -1,4 +1,39 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "custom_course")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "사용자 정의 커스텀 코스 엔티티")
 public class CustomCourseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "커스텀 코스 ID", example = "10")
+    private Long id;
+
+    @Schema(description = "사용자 ID", example = "42")
+    private Long userId;
+
+    @Schema(description = "코스 제목", example = "한강 러닝 코스")
+    private String title;
+
+    @Schema(description = "총 거리 (km)", example = "12.3")
+    private Double totalDistanceKm;
+
+    @Schema(description = "생성일시")
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CourseSegmentEntity> segments;
 }

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/CustomCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/CustomCourseEntity.java
@@ -34,6 +34,7 @@ public class CustomCourseEntity {
     @Schema(description = "생성일시")
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "customCourse", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CourseSegmentEntity> segments;
+
 }

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/CustomCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/CustomCourseEntity.java
@@ -1,0 +1,4 @@
+package com.waytoearth.entity.VirtualRunning;
+
+public class CustomCourseEntity {
+}

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentLandmarkEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentLandmarkEntity.java
@@ -1,4 +1,39 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "segment_landmark")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "세그먼트 랜드마크 엔티티")
 public class SegmentLandmarkEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "랜드마크 ID", example = "501")
+    private Long id;
+
+    @Schema(description = "세그먼트 ID", example = "100")
+    private Long segmentId;
+
+    @Schema(description = "랜드마크 이름", example = "남산타워")
+    private String name;
+
+    @Schema(description = "위도", example = "37.5512")
+    private Double latitude;
+
+    @Schema(description = "경도", example = "126.9882")
+    private Double longitude;
+
+    @Schema(description = "사진 URL", example = "https://example.com/namsan.jpg")
+    private String photoUrl;
+
+    @Schema(description = "설명", example = "서울의 대표적인 전망 명소")
+    private String description;
 }

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentLandmarkEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentLandmarkEntity.java
@@ -1,0 +1,4 @@
+package com.waytoearth.entity.VirtualRunning;
+
+public class SegmentLandmarkEntity {
+}

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentProgressEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentProgressEntity.java
@@ -1,0 +1,4 @@
+package com.waytoearth.entity.VirtualRunning;
+
+public class SegmentProgressEntity {
+}

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentProgressEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentProgressEntity.java
@@ -1,4 +1,36 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import com.waytoearth.entity.enums.VirtualCourseStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "segment_progress")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "사용자의 세그먼트별 진행률 엔티티")
 public class SegmentProgressEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "세그먼트 진행 ID", example = "300")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_virtual_course_id")
+    private UserVirtualCourseEntity userVirtualCourse;
+
+    @Schema(description = "세그먼트 ID", example = "100")
+    private Long segmentId;
+
+    @Schema(description = "세그먼트 누적 거리 (km)", example = "15.2")
+    private Double distanceAccumulated;
+
+    @Enumerated(EnumType.STRING)
+    @Schema(description = "진행 상태", example = "ACTIVE")
+    private VirtualCourseStatus status;
 }

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/ThemeCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/ThemeCourseEntity.java
@@ -1,4 +1,39 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "theme_course")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "운영자 제공 테마 코스 엔티티")
 public class ThemeCourseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "코스 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "코스 제목", example = "서울 → 부산")
+    private String title;
+
+    @Schema(description = "코스 설명", example = "국내 대표 장거리 러닝 코스")
+    private String description;
+
+    @Schema(description = "총 거리 (km)", example = "350.5")
+    private Double totalDistanceKm;
+
+    @Schema(description = "생성일시")
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<CourseSegmentEntity> segments;
 }

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/ThemeCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/ThemeCourseEntity.java
@@ -34,6 +34,6 @@ public class ThemeCourseEntity {
     @Schema(description = "생성일시")
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "themeCourse", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CourseSegmentEntity> segments;
 }

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/ThemeCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/ThemeCourseEntity.java
@@ -1,0 +1,4 @@
+package com.waytoearth.entity.VirtualRunning;
+
+public class ThemeCourseEntity {
+}

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/UserVirtualCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/UserVirtualCourseEntity.java
@@ -26,6 +26,10 @@ public class UserVirtualCourseEntity {
     @Schema(description = "코스 ID", example = "10")
     private Long courseId;
 
+    @Enumerated(EnumType.STRING)
+    @Schema(description = "코스 타입 (CUSTOM, THEME)", example = "CUSTOM")
+    private CourseType courseType;   // ✅ 추가
+
     @Schema(description = "진행률 (%)", example = "35.7")
     private Double progressPercent;
 
@@ -35,4 +39,9 @@ public class UserVirtualCourseEntity {
     @Enumerated(EnumType.STRING)
     @Schema(description = "진행 상태", example = "ACTIVE")
     private VirtualCourseStatus status;
+
+    // ✅ Enum 정의 (내부 또는 별도 파일로 관리 가능)
+    public enum CourseType {
+        CUSTOM, THEME
+    }
 }

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/UserVirtualCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/UserVirtualCourseEntity.java
@@ -1,0 +1,4 @@
+package com.waytoearth.entity.VirtualRunning;
+
+public class UserVirtualCourseEntity {
+}

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/UserVirtualCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/UserVirtualCourseEntity.java
@@ -1,4 +1,38 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import com.waytoearth.entity.enums.VirtualCourseStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_virtual_course")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "사용자 가상 코스 진행 상태 엔티티")
 public class UserVirtualCourseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "사용자 코스 진행 ID", example = "200")
+    private Long id;
+
+    @Schema(description = "사용자 ID", example = "42")
+    private Long userId;
+
+    @Schema(description = "코스 ID", example = "10")
+    private Long courseId;
+
+    @Schema(description = "진행률 (%)", example = "35.7")
+    private Double progressPercent;
+
+    @Schema(description = "누적 거리 (km)", example = "123.4")
+    private Double totalDistanceAccumulated;
+
+    @Enumerated(EnumType.STRING)
+    @Schema(description = "진행 상태", example = "ACTIVE")
+    private VirtualCourseStatus status;
 }

--- a/src/main/java/com/waytoearth/entity/enums/SegmentType.java
+++ b/src/main/java/com/waytoearth/entity/enums/SegmentType.java
@@ -1,0 +1,10 @@
+package com.waytoearth.entity.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "세그먼트 타입 ENUM")
+public enum SegmentType {
+    DOMESTIC,      // 국내 구간
+    FLIGHT,        // 항공 구간
+    INTERNATIONAL  // 해외 구간
+}

--- a/src/main/java/com/waytoearth/entity/enums/VirtualCourseStatus.java
+++ b/src/main/java/com/waytoearth/entity/enums/VirtualCourseStatus.java
@@ -1,0 +1,8 @@
+package com.waytoearth.entity.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "가상 코스 진행 상태 ENUM")
+public enum VirtualCourseStatus {
+    ACTIVE, COMPLETED
+}

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/CourseSegmentRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/CourseSegmentRepository.java
@@ -9,5 +9,10 @@ import java.util.List;
  * 코스 세그먼트 Repository
  */
 public interface CourseSegmentRepository extends JpaRepository<CourseSegmentEntity, Long> {
-    List<CourseSegmentEntity> findByCourseIdOrderByOrderIndex(Long courseId);
+
+    // 테마 코스 기준 조회
+    List<CourseSegmentEntity> findByThemeCourseIdOrderByOrderIndex(Long themeCourseId);
+
+    // 커스텀 코스 기준 조회
+    List<CourseSegmentEntity> findByCustomCourseIdOrderByOrderIndex(Long customCourseId);
 }

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/CourseSegmentRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/CourseSegmentRepository.java
@@ -1,0 +1,4 @@
+package com.waytoearth.repository.VirtualRunning;
+
+public class CourseSegmentRepository {
+}

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/CourseSegmentRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/CourseSegmentRepository.java
@@ -1,4 +1,13 @@
 package com.waytoearth.repository.VirtualRunning;
 
-public class CourseSegmentRepository {
+import com.waytoearth.entity.VirtualRunning.CourseSegmentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * 코스 세그먼트 Repository
+ */
+public interface CourseSegmentRepository extends JpaRepository<CourseSegmentEntity, Long> {
+    List<CourseSegmentEntity> findByCourseIdOrderByOrderIndex(Long courseId);
 }

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/CustomCourseRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/CustomCourseRepository.java
@@ -1,4 +1,13 @@
 package com.waytoearth.repository.VirtualRunning;
 
-public class CustomCourseRepository {
+import com.waytoearth.entity.VirtualRunning.CustomCourseEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * 사용자 커스텀 코스 Repository
+ */
+public interface CustomCourseRepository extends JpaRepository<CustomCourseEntity, Long> {
+    List<CustomCourseEntity> findByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/CustomCourseRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/CustomCourseRepository.java
@@ -1,0 +1,4 @@
+package com.waytoearth.repository.VirtualRunning;
+
+public class CustomCourseRepository {
+}

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/SegmentLandmarkRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/SegmentLandmarkRepository.java
@@ -1,0 +1,4 @@
+package com.waytoearth.repository.VirtualRunning;
+
+public class SegmentLandmarkRepository {
+}

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/SegmentLandmarkRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/SegmentLandmarkRepository.java
@@ -1,4 +1,13 @@
 package com.waytoearth.repository.VirtualRunning;
 
-public class SegmentLandmarkRepository {
+import com.waytoearth.entity.VirtualRunning.SegmentLandmarkEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * 세그먼트 랜드마크 Repository
+ */
+public interface SegmentLandmarkRepository extends JpaRepository<SegmentLandmarkEntity, Long> {
+    List<SegmentLandmarkEntity> findBySegmentId(Long segmentId);
 }

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/SegmentProgressRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/SegmentProgressRepository.java
@@ -1,0 +1,10 @@
+package com.waytoearth.repository.VirtualRunning;
+
+import com.waytoearth.entity.VirtualRunning.SegmentProgressEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SegmentProgressRepository extends JpaRepository<SegmentProgressEntity, Long> {
+    List<SegmentProgressEntity> findByUserVirtualCourseId(Long userVirtualCourseId);
+}

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/ThemeCourseRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/ThemeCourseRepository.java
@@ -1,0 +1,4 @@
+package com.waytoearth.repository.VirtualRunning;
+
+public class ThemeCourseRepository {
+}

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/ThemeCourseRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/ThemeCourseRepository.java
@@ -1,4 +1,10 @@
 package com.waytoearth.repository.VirtualRunning;
 
-public class ThemeCourseRepository {
+import com.waytoearth.entity.VirtualRunning.ThemeCourseEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 운영자 제공 테마 코스 Repository
+ */
+public interface ThemeCourseRepository extends JpaRepository<ThemeCourseEntity, Long> {
 }

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/UserVirtualCourseRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/UserVirtualCourseRepository.java
@@ -1,4 +1,10 @@
 package com.waytoearth.repository.VirtualRunning;
 
-public class UserVirtualCourseRepository {
+import com.waytoearth.entity.VirtualRunning.UserVirtualCourseEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserVirtualCourseRepository extends JpaRepository<UserVirtualCourseEntity, Long> {
+    List<UserVirtualCourseEntity> findByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/VirtualRunning/UserVirtualCourseRepository.java
+++ b/src/main/java/com/waytoearth/repository/VirtualRunning/UserVirtualCourseRepository.java
@@ -1,0 +1,4 @@
+package com.waytoearth.repository.VirtualRunning;
+
+public class UserVirtualCourseRepository {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentService.java
@@ -6,12 +6,21 @@ import com.waytoearth.dto.response.Virtual.CourseSegmentSummaryResponse;
 
 import java.util.List;
 
-/**
- * 세그먼트 관리 서비스
- */
+
+
 public interface CourseSegmentService {
-    CourseSegmentDetailResponse addSegment(Long courseId, CourseSegmentCreateRequest request);
-    List<CourseSegmentSummaryResponse> getSegments(Long courseId);
+
+    // 테마 코스
+    CourseSegmentDetailResponse addSegmentToThemeCourse(Long themeCourseId, CourseSegmentCreateRequest request);
+    List<CourseSegmentSummaryResponse> getSegmentsByThemeCourse(Long themeCourseId);
+
+    // 커스텀 코스
+    CourseSegmentDetailResponse addSegmentToCustomCourse(Long customCourseId, CourseSegmentCreateRequest request);
+    List<CourseSegmentSummaryResponse> getSegmentsByCustomCourse(Long customCourseId);
+
+    // 공통
     CourseSegmentDetailResponse getSegmentDetail(Long segmentId);
     void deleteSegment(Long segmentId);
 }
+
+

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentService.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class CourseSegmentService {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentService.java
@@ -1,4 +1,17 @@
 package com.waytoearth.service.VirtualRunning;
 
-public class CourseSegmentService {
+import com.waytoearth.dto.request.Virtual.CourseSegmentCreateRequest;
+import com.waytoearth.dto.response.Virtual.CourseSegmentDetailResponse;
+import com.waytoearth.dto.response.Virtual.CourseSegmentSummaryResponse;
+
+import java.util.List;
+
+/**
+ * 세그먼트 관리 서비스
+ */
+public interface CourseSegmentService {
+    CourseSegmentDetailResponse addSegment(Long courseId, CourseSegmentCreateRequest request);
+    List<CourseSegmentSummaryResponse> getSegments(Long courseId);
+    CourseSegmentDetailResponse getSegmentDetail(Long segmentId);
+    void deleteSegment(Long segmentId);
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentServiceImpl.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class CourseSegmentServiceImpl {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentServiceImpl.java
@@ -1,4 +1,83 @@
 package com.waytoearth.service.VirtualRunning;
 
-public class CourseSegmentServiceImpl {
+import com.waytoearth.dto.request.Virtual.CourseSegmentCreateRequest;
+import com.waytoearth.dto.response.Virtual.CourseSegmentDetailResponse;
+import com.waytoearth.dto.response.Virtual.CourseSegmentSummaryResponse;
+import com.waytoearth.entity.VirtualRunning.CourseSegmentEntity;
+import com.waytoearth.repository.VirtualRunning.CourseSegmentRepository;
+import com.waytoearth.repository.VirtualRunning.CustomCourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CourseSegmentServiceImpl implements CourseSegmentService {
+
+    private final CourseSegmentRepository courseSegmentRepository;
+    private final CustomCourseRepository customCourseRepository;
+
+    @Override
+    public CourseSegmentDetailResponse addSegment(Long courseId, CourseSegmentCreateRequest request) {
+        var course = customCourseRepository.findById(courseId)
+                .orElseThrow(() -> new IllegalArgumentException("코스를 찾을 수 없습니다."));
+
+        var segment = CourseSegmentEntity.builder()
+                .course(course)
+                .type(request.getType())
+                .orderIndex(request.getOrderIndex())
+                .startLat(request.getStartLat())
+                .startLng(request.getStartLng())
+                .endLat(request.getEndLat())
+                .endLng(request.getEndLng())
+                .distanceKm(request.getDistanceKm())
+                .build();
+
+        var saved = courseSegmentRepository.save(segment);
+
+        return new CourseSegmentDetailResponse(
+                saved.getId(),
+                saved.getType().name(),
+                saved.getStartLat(),
+                saved.getStartLng(),
+                saved.getEndLat(),
+                saved.getEndLng(),
+                saved.getDistanceKm()
+        );
+    }
+
+    @Override
+    public List<CourseSegmentSummaryResponse> getSegments(Long courseId) {
+        return courseSegmentRepository.findByCourseIdOrderByOrderIndex(courseId)
+                .stream()
+                .map(seg -> new CourseSegmentSummaryResponse(
+                        seg.getId(),
+                        seg.getOrderIndex(),
+                        seg.getDistanceKm()
+                ))
+                .toList();
+    }
+
+    @Override
+    public CourseSegmentDetailResponse getSegmentDetail(Long segmentId) {
+        var seg = courseSegmentRepository.findById(segmentId)
+                .orElseThrow(() -> new IllegalArgumentException("세그먼트를 찾을 수 없습니다."));
+        return new CourseSegmentDetailResponse(
+                seg.getId(),
+                seg.getType().name(),
+                seg.getStartLat(),
+                seg.getStartLng(),
+                seg.getEndLat(),
+                seg.getEndLng(),
+                seg.getDistanceKm()
+        );
+    }
+
+    @Override
+    public void deleteSegment(Long segmentId) {
+        courseSegmentRepository.deleteById(segmentId);
+    }
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CourseSegmentServiceImpl.java
@@ -5,6 +5,7 @@ import com.waytoearth.dto.response.Virtual.CourseSegmentDetailResponse;
 import com.waytoearth.dto.response.Virtual.CourseSegmentSummaryResponse;
 import com.waytoearth.entity.VirtualRunning.CourseSegmentEntity;
 import com.waytoearth.repository.VirtualRunning.CourseSegmentRepository;
+import com.waytoearth.repository.VirtualRunning.ThemeCourseRepository;
 import com.waytoearth.repository.VirtualRunning.CustomCourseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,15 +19,17 @@ import java.util.List;
 public class CourseSegmentServiceImpl implements CourseSegmentService {
 
     private final CourseSegmentRepository courseSegmentRepository;
+    private final ThemeCourseRepository themeCourseRepository;
     private final CustomCourseRepository customCourseRepository;
 
+    // ✅ 테마 코스에 세그먼트 추가
     @Override
-    public CourseSegmentDetailResponse addSegment(Long courseId, CourseSegmentCreateRequest request) {
-        var course = customCourseRepository.findById(courseId)
-                .orElseThrow(() -> new IllegalArgumentException("코스를 찾을 수 없습니다."));
+    public CourseSegmentDetailResponse addSegmentToThemeCourse(Long themeCourseId, CourseSegmentCreateRequest request) {
+        var themeCourse = themeCourseRepository.findById(themeCourseId)
+                .orElseThrow(() -> new IllegalArgumentException("테마 코스를 찾을 수 없습니다. id=" + themeCourseId));
 
         var segment = CourseSegmentEntity.builder()
-                .course(course)
+                .themeCourse(themeCourse)
                 .type(request.getType())
                 .orderIndex(request.getOrderIndex())
                 .startLat(request.getStartLat())
@@ -49,9 +52,40 @@ public class CourseSegmentServiceImpl implements CourseSegmentService {
         );
     }
 
+    // ✅ 커스텀 코스에 세그먼트 추가
     @Override
-    public List<CourseSegmentSummaryResponse> getSegments(Long courseId) {
-        return courseSegmentRepository.findByCourseIdOrderByOrderIndex(courseId)
+    public CourseSegmentDetailResponse addSegmentToCustomCourse(Long customCourseId, CourseSegmentCreateRequest request) {
+        var customCourse = customCourseRepository.findById(customCourseId)
+                .orElseThrow(() -> new IllegalArgumentException("커스텀 코스를 찾을 수 없습니다. id=" + customCourseId));
+
+        var segment = CourseSegmentEntity.builder()
+                .customCourse(customCourse)
+                .type(request.getType())
+                .orderIndex(request.getOrderIndex())
+                .startLat(request.getStartLat())
+                .startLng(request.getStartLng())
+                .endLat(request.getEndLat())
+                .endLng(request.getEndLng())
+                .distanceKm(request.getDistanceKm())
+                .build();
+
+        var saved = courseSegmentRepository.save(segment);
+
+        return new CourseSegmentDetailResponse(
+                saved.getId(),
+                saved.getType().name(),
+                saved.getStartLat(),
+                saved.getStartLng(),
+                saved.getEndLat(),
+                saved.getEndLng(),
+                saved.getDistanceKm()
+        );
+    }
+
+    // ✅ 테마 코스 세그먼트 목록
+    @Override
+    public List<CourseSegmentSummaryResponse> getSegmentsByThemeCourse(Long themeCourseId) {
+        return courseSegmentRepository.findByThemeCourseIdOrderByOrderIndex(themeCourseId)
                 .stream()
                 .map(seg -> new CourseSegmentSummaryResponse(
                         seg.getId(),
@@ -61,10 +95,25 @@ public class CourseSegmentServiceImpl implements CourseSegmentService {
                 .toList();
     }
 
+    // ✅ 커스텀 코스 세그먼트 목록
+    @Override
+    public List<CourseSegmentSummaryResponse> getSegmentsByCustomCourse(Long customCourseId) {
+        return courseSegmentRepository.findByCustomCourseIdOrderByOrderIndex(customCourseId)
+                .stream()
+                .map(seg -> new CourseSegmentSummaryResponse(
+                        seg.getId(),
+                        seg.getOrderIndex(),
+                        seg.getDistanceKm()
+                ))
+                .toList();
+    }
+
+    // ✅ 세그먼트 상세 조회
     @Override
     public CourseSegmentDetailResponse getSegmentDetail(Long segmentId) {
         var seg = courseSegmentRepository.findById(segmentId)
-                .orElseThrow(() -> new IllegalArgumentException("세그먼트를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("세그먼트를 찾을 수 없습니다. id=" + segmentId));
+
         return new CourseSegmentDetailResponse(
                 seg.getId(),
                 seg.getType().name(),
@@ -76,6 +125,7 @@ public class CourseSegmentServiceImpl implements CourseSegmentService {
         );
     }
 
+    // ✅ 세그먼트 삭제
     @Override
     public void deleteSegment(Long segmentId) {
         courseSegmentRepository.deleteById(segmentId);

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseService.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class CustomCourseService {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseService.java
@@ -1,4 +1,17 @@
 package com.waytoearth.service.VirtualRunning;
 
-public class CustomCourseService {
+import com.waytoearth.dto.request.Virtual.CustomCourseCreateRequest;
+import com.waytoearth.dto.response.Virtual.CustomCourseDetailResponse;
+import com.waytoearth.dto.response.Virtual.CustomCourseSummaryResponse;
+
+import java.util.List;
+
+/**
+ * 사용자 커스텀 코스 서비스
+ */
+public interface CustomCourseService {
+    CustomCourseDetailResponse createCourse(CustomCourseCreateRequest request);
+    List<CustomCourseSummaryResponse> getUserCourses(Long userId);
+    CustomCourseDetailResponse getCourseDetail(Long courseId);
+    void deleteCourse(Long courseId, Long userId);
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseServiceImpl.java
@@ -9,6 +9,8 @@ import com.waytoearth.repository.VirtualRunning.CustomCourseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.waytoearth.dto.request.Virtual.CourseSegmentCreateRequest;
+
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseServiceImpl.java
@@ -1,4 +1,89 @@
 package com.waytoearth.service.VirtualRunning;
 
-public class CustomCourseServiceImpl {
+import com.waytoearth.dto.request.Virtual.CustomCourseCreateRequest;
+import com.waytoearth.dto.response.Virtual.CourseSegmentDetailResponse;
+import com.waytoearth.dto.response.Virtual.CustomCourseDetailResponse;
+import com.waytoearth.dto.response.Virtual.CustomCourseSummaryResponse;
+import com.waytoearth.entity.VirtualRunning.CustomCourseEntity;
+import com.waytoearth.repository.VirtualRunning.CustomCourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CustomCourseServiceImpl implements CustomCourseService {
+
+    private final CustomCourseRepository customCourseRepository;
+
+    @Override
+    public CustomCourseDetailResponse createCourse(CustomCourseCreateRequest request) {
+        CustomCourseEntity course = CustomCourseEntity.builder()
+                .userId(request.getUserId())
+                .title(request.getTitle())
+                .totalDistanceKm(request.getSegments().stream()
+                        .mapToDouble(CourseSegmentCreateRequest::getDistanceKm)
+                        .sum())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        CustomCourseEntity saved = customCourseRepository.save(course);
+
+        return new CustomCourseDetailResponse(
+                saved.getId(),
+                saved.getTitle(),
+                saved.getTotalDistanceKm(),
+                List.of() // TODO: 세그먼트 저장 후 매핑
+        );
+    }
+
+    @Override
+    public List<CustomCourseSummaryResponse> getUserCourses(Long userId) {
+        return customCourseRepository.findByUserId(userId).stream()
+                .map(course -> new CustomCourseSummaryResponse(
+                        course.getId(),
+                        course.getTitle(),
+                        course.getTotalDistanceKm()
+                ))
+                .toList();
+    }
+
+    @Override
+    public CustomCourseDetailResponse getCourseDetail(Long courseId) {
+        CustomCourseEntity course = customCourseRepository.findById(courseId)
+                .orElseThrow(() -> new IllegalArgumentException("커스텀 코스를 찾을 수 없습니다. id=" + courseId));
+
+        return new CustomCourseDetailResponse(
+                course.getId(),
+                course.getTitle(),
+                course.getTotalDistanceKm(),
+                course.getSegments().stream()
+                        .map(segment -> new CourseSegmentDetailResponse(
+                                segment.getId(),
+                                segment.getType().name(),
+                                segment.getStartLat(),
+                                segment.getStartLng(),
+                                segment.getEndLat(),
+                                segment.getEndLng(),
+                                segment.getDistanceKm()
+                        ))
+                        .toList()
+        );
+    }
+
+    @Override
+    public void deleteCourse(Long courseId, Long userId) {
+        CustomCourseEntity course = customCourseRepository.findById(courseId)
+                .orElseThrow(() -> new IllegalArgumentException("코스를 찾을 수 없습니다."));
+
+        if (!course.getUserId().equals(userId)) {
+            throw new IllegalStateException("본인 소유 코스만 삭제할 수 있습니다.");
+        }
+
+        customCourseRepository.delete(course);
+    }
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseServiceImpl.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class CustomCourseServiceImpl {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/SegmentEmblemService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/SegmentEmblemService.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class SegmentEmblemService {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/SegmentEmblemService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/SegmentEmblemService.java
@@ -1,4 +1,22 @@
 package com.waytoearth.service.VirtualRunning;
 
+import com.waytoearth.dto.response.Virtual.SegmentEmblemResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.stereotype.Service;
+
+@Service
+@Schema(description = "세그먼트 엠블럼 서비스")
 public class SegmentEmblemService {
+
+    public SegmentEmblemResponse checkEmblem(Long userVirtualCourseId, Long segmentId, Double distance) {
+        // TODO: 실제 조건 확인 로직 (예: segment 완주, 누적 거리 milestone)
+        if (distance >= 10.0) {
+            return new SegmentEmblemResponse(
+                    segmentId,
+                    "10km 달성!",
+                    "EMBLEM_10K"
+            );
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/SegmentLandmarkService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/SegmentLandmarkService.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class SegmentLandmarkService {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/SegmentLandmarkService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/SegmentLandmarkService.java
@@ -1,4 +1,30 @@
 package com.waytoearth.service.VirtualRunning;
 
+import com.waytoearth.dto.response.Virtual.SegmentLandmarkResponse;
+import com.waytoearth.repository.VirtualRunning.SegmentLandmarkRepository;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Schema(description = "세그먼트 랜드마크 서비스")
 public class SegmentLandmarkService {
+
+    private final SegmentLandmarkRepository segmentLandmarkRepository;
+
+    public List<SegmentLandmarkResponse> getLandmarks(Long segmentId) {
+        return segmentLandmarkRepository.findBySegmentId(segmentId).stream()
+                .map(lm -> new SegmentLandmarkResponse(
+                        lm.getId(),
+                        lm.getName(),
+                        lm.getLatitude(),
+                        lm.getLongitude(),
+                        lm.getPhotoUrl(),
+                        lm.getDescription()
+                ))
+                .toList();
+    }
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/SegmentWeatherService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/SegmentWeatherService.java
@@ -1,4 +1,21 @@
 package com.waytoearth.service.VirtualRunning;
 
+import com.waytoearth.dto.response.Virtual.SegmentWeatherResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.stereotype.Service;
+
+@Service
+@Schema(description = "세그먼트 날씨 서비스")
 public class SegmentWeatherService {
+
+    public SegmentWeatherResponse getWeather(Long segmentId) {
+        // TODO: segment 좌표 조회 후 실제 날씨 API 연동
+        // 지금은 Mock 데이터 반환
+        return new SegmentWeatherResponse(
+                segmentId,
+                "맑음",
+                26.5,
+                2.3
+        );
+    }
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/SegmentWeatherService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/SegmentWeatherService.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class SegmentWeatherService {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/ThemeCourseService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/ThemeCourseService.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class ThemeCourseService {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/ThemeCourseService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/ThemeCourseService.java
@@ -1,4 +1,14 @@
 package com.waytoearth.service.VirtualRunning;
 
-public class ThemeCourseService {
+import com.waytoearth.dto.response.Virtual.ThemeCourseDetailResponse;
+import com.waytoearth.dto.response.Virtual.ThemeCourseSummaryResponse;
+
+import java.util.List;
+
+/**
+ * 운영자 제공 테마 코스 서비스
+ */
+public interface ThemeCourseService {
+    List<ThemeCourseSummaryResponse> getThemeCourses();
+    ThemeCourseDetailResponse getThemeCourseDetail(Long courseId);
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/ThemeCourseServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/ThemeCourseServiceImpl.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class ThemeCourseServiceImpl {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/ThemeCourseServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/ThemeCourseServiceImpl.java
@@ -1,4 +1,54 @@
 package com.waytoearth.service.VirtualRunning;
 
-public class ThemeCourseServiceImpl {
+import com.waytoearth.dto.response.Virtual.CourseSegmentDetailResponse;
+import com.waytoearth.dto.response.Virtual.ThemeCourseDetailResponse;
+import com.waytoearth.dto.response.Virtual.ThemeCourseSummaryResponse;
+import com.waytoearth.repository.VirtualRunning.ThemeCourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ThemeCourseServiceImpl implements ThemeCourseService {
+
+    private final ThemeCourseRepository themeCourseRepository;
+
+    @Override
+    public List<ThemeCourseSummaryResponse> getThemeCourses() {
+        return themeCourseRepository.findAll().stream()
+                .map(course -> new ThemeCourseSummaryResponse(
+                        course.getId(),
+                        course.getTitle(),
+                        course.getTotalDistanceKm()
+                ))
+                .toList();
+    }
+
+    @Override
+    public ThemeCourseDetailResponse getThemeCourseDetail(Long courseId) {
+        var course = themeCourseRepository.findById(courseId)
+                .orElseThrow(() -> new IllegalArgumentException("코스를 찾을 수 없습니다. id=" + courseId));
+
+        return new ThemeCourseDetailResponse(
+                course.getId(),
+                course.getTitle(),
+                course.getDescription(),
+                course.getTotalDistanceKm(),
+                course.getSegments().stream()
+                        .map(segment -> new CourseSegmentDetailResponse(
+                                segment.getId(),
+                                segment.getType().name(),
+                                segment.getStartLat(),
+                                segment.getStartLng(),
+                                segment.getEndLat(),
+                                segment.getEndLng(),
+                                segment.getDistanceKm()
+                        ))
+                        .toList()
+        );
+    }
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/UserVirtualCourseService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/UserVirtualCourseService.java
@@ -1,4 +1,13 @@
 package com.waytoearth.service.VirtualRunning;
 
-public class UserVirtualCourseService {
+import com.waytoearth.dto.request.Virtual.VirtualCourseProgressUpdateRequest;
+import com.waytoearth.dto.response.Virtual.SegmentProgressResponse;
+import com.waytoearth.dto.response.Virtual.VirtualCourseProgressResponse;
+
+import java.util.List;
+
+public interface UserVirtualCourseService {
+    VirtualCourseProgressResponse updateProgress(Long userVirtualCourseId, VirtualCourseProgressUpdateRequest request);
+    VirtualCourseProgressResponse getProgress(Long userVirtualCourseId);
+    List<SegmentProgressResponse> getSegmentProgress(Long userVirtualCourseId);
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/UserVirtualCourseService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/UserVirtualCourseService.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class UserVirtualCourseService {
+}

--- a/src/main/java/com/waytoearth/service/VirtualRunning/UserVirtualCourseService.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/UserVirtualCourseService.java
@@ -1,7 +1,9 @@
 package com.waytoearth.service.VirtualRunning;
 
+import com.waytoearth.dto.request.Virtual.UserVirtualCourseCreateRequest;
 import com.waytoearth.dto.request.Virtual.VirtualCourseProgressUpdateRequest;
 import com.waytoearth.dto.response.Virtual.SegmentProgressResponse;
+import com.waytoearth.dto.response.Virtual.UserVirtualCourseResponse;
 import com.waytoearth.dto.response.Virtual.VirtualCourseProgressResponse;
 
 import java.util.List;
@@ -10,4 +12,5 @@ public interface UserVirtualCourseService {
     VirtualCourseProgressResponse updateProgress(Long userVirtualCourseId, VirtualCourseProgressUpdateRequest request);
     VirtualCourseProgressResponse getProgress(Long userVirtualCourseId);
     List<SegmentProgressResponse> getSegmentProgress(Long userVirtualCourseId);
+    UserVirtualCourseResponse createUserVirtualCourse(UserVirtualCourseCreateRequest request);
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/UserVirtualCourseServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/UserVirtualCourseServiceImpl.java
@@ -1,4 +1,81 @@
 package com.waytoearth.service.VirtualRunning;
 
-public class UserVirtualCourseServiceImpl {
+import com.waytoearth.dto.request.Virtual.VirtualCourseProgressUpdateRequest;
+import com.waytoearth.dto.response.Virtual.SegmentProgressResponse;
+import com.waytoearth.dto.response.Virtual.VirtualCourseProgressResponse;
+import com.waytoearth.repository.VirtualRunning.SegmentProgressRepository;
+import com.waytoearth.repository.VirtualRunning.UserVirtualCourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserVirtualCourseServiceImpl implements UserVirtualCourseService {
+
+    private final UserVirtualCourseRepository userVirtualCourseRepository;
+    private final SegmentProgressRepository segmentProgressRepository;
+
+    @Override
+    public VirtualCourseProgressResponse updateProgress(Long userVirtualCourseId, VirtualCourseProgressUpdateRequest request) {
+        var userCourse = userVirtualCourseRepository.findById(userVirtualCourseId)
+                .orElseThrow(() -> new IllegalArgumentException("진행 중인 코스를 찾을 수 없습니다."));
+
+        // 세그먼트 진행률 업데이트
+        var segmentProgress = segmentProgressRepository.findByUserVirtualCourseId(userVirtualCourseId).stream()
+                .filter(sp -> sp.getSegmentId().equals(request.getSegmentId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("세그먼트 진행 데이터를 찾을 수 없습니다."));
+
+        segmentProgress.setDistanceAccumulated(
+                segmentProgress.getDistanceAccumulated() + request.getDistanceKm()
+        );
+        segmentProgressRepository.save(segmentProgress);
+
+        // 전체 코스 진행률 업데이트
+        double newTotal = userCourse.getTotalDistanceAccumulated() + request.getDistanceKm();
+        userCourse.setTotalDistanceAccumulated(newTotal);
+        userCourse.setProgressPercent(calculateProgressPercent(userCourse.getCourseId(), newTotal));
+
+        userVirtualCourseRepository.save(userCourse);
+
+        return new VirtualCourseProgressResponse(
+                userCourse.getProgressPercent(),
+                userCourse.getTotalDistanceAccumulated(),
+                userCourse.getStatus().name()
+        );
+    }
+
+    @Override
+    public VirtualCourseProgressResponse getProgress(Long userVirtualCourseId) {
+        var userCourse = userVirtualCourseRepository.findById(userVirtualCourseId)
+                .orElseThrow(() -> new IllegalArgumentException("진행 중인 코스를 찾을 수 없습니다."));
+
+        return new VirtualCourseProgressResponse(
+                userCourse.getProgressPercent(),
+                userCourse.getTotalDistanceAccumulated(),
+                userCourse.getStatus().name()
+        );
+    }
+
+    @Override
+    public List<SegmentProgressResponse> getSegmentProgress(Long userVirtualCourseId) {
+        return segmentProgressRepository.findByUserVirtualCourseId(userVirtualCourseId)
+                .stream()
+                .map(sp -> new SegmentProgressResponse(
+                        sp.getSegmentId(),
+                        sp.getDistanceAccumulated(),
+                        sp.getStatus().name()
+                ))
+                .toList();
+    }
+
+    private double calculateProgressPercent(Long courseId, double totalDistance) {
+        // TODO: 실제 CourseRepository에서 총 거리 가져와 계산
+        double courseTotal = 100.0; // 임시 값
+        return Math.min(100.0, (totalDistance / courseTotal) * 100);
+    }
 }

--- a/src/main/java/com/waytoearth/service/VirtualRunning/UserVirtualCourseServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/UserVirtualCourseServiceImpl.java
@@ -1,0 +1,4 @@
+package com.waytoearth.service.VirtualRunning;
+
+public class UserVirtualCourseServiceImpl {
+}

--- a/src/main/java/com/waytoearth/service/running/RunningService.java
+++ b/src/main/java/com/waytoearth/service/running/RunningService.java
@@ -1,8 +1,12 @@
 package com.waytoearth.service.running;
 
 import com.waytoearth.dto.request.running.*;
-import com.waytoearth.dto.response.running.*;
+import com.waytoearth.dto.response.running.RunningCompleteResponse;
+import com.waytoearth.dto.response.running.RunningRecordSummaryResponse;
+import com.waytoearth.dto.response.running.RunningStartResponse;
 import com.waytoearth.security.AuthenticatedUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface RunningService {
 
@@ -22,4 +26,6 @@ public interface RunningService {
 
     // 완료 페이지 재조회(경로 포함)
     RunningCompleteResponse getDetail(AuthenticatedUser user, Long recordId);
+
+    Page<RunningRecordSummaryResponse> getRecords(AuthenticatedUser authUser, Pageable pageable);
 }

--- a/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,23 +31,21 @@ public class RunningServiceImpl implements RunningService {
     private final RunningRecordRepository runningRecordRepository;
     private final RunningRouteRepository runningRouteRepository;
     private final UserRepository userRepository;
-    private final EmblemService emblemService;  //엠블럼 자동 지급을 위한 의존성 주입
-
+    private final EmblemService emblemService;  // 엠블럼 자동 지급
 
     @Override
     public RunningStartResponse startRunning(AuthenticatedUser authUser, RunningStartRequest request) {
         User runner = userRepository.findById(authUser.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        //  Builder 패턴으로 안전하게 생성
         RunningRecord record = RunningRecord.builder()
-                .sessionId(request.getSessionId()) //  요청에서 받은 sessionId 사용
+                .sessionId(request.getSessionId())
                 .user(runner)
                 .runningType(request.getRunningType() != null ? request.getRunningType() : RunningType.SINGLE)
                 .virtualCourseId(request.getVirtualCourseId())
                 .status(RunningStatus.RUNNING)
                 .startedAt(LocalDateTime.now())
-                .isCompleted(false) //  필수 필드 명시적 설정
+                .isCompleted(false)
                 .build();
 
         runningRecordRepository.save(record);
@@ -60,12 +57,10 @@ public class RunningServiceImpl implements RunningService {
         RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
                 .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
 
-        // 권한 검증 추가
         if (!record.getUser().getId().equals(authUser.getUserId())) {
             throw new IllegalArgumentException("해당 세션에 대한 권한이 없습니다.");
         }
 
-        // 누적값 반영 (m → km)
         record.setDistance(BigDecimal.valueOf(request.getDistanceMeters() / 1000.0));
         record.setDuration(request.getDurationSeconds());
         record.setAveragePaceSeconds(request.getAveragePaceSeconds());
@@ -79,7 +74,7 @@ public class RunningServiceImpl implements RunningService {
             );
         }
 
-        runningRecordRepository.save(record); //  저장 추가
+        runningRecordRepository.save(record);
     }
 
     @Override
@@ -87,13 +82,12 @@ public class RunningServiceImpl implements RunningService {
         RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
                 .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
 
-        // 권한 검증 추가
         if (!record.getUser().getId().equals(authUser.getUserId())) {
             throw new IllegalArgumentException("해당 세션에 대한 권한이 없습니다.");
         }
 
         record.setStatus(RunningStatus.PAUSED);
-        runningRecordRepository.save(record); //  저장 추가
+        runningRecordRepository.save(record);
     }
 
     @Override
@@ -113,32 +107,17 @@ public class RunningServiceImpl implements RunningService {
         runningRecordRepository.save(record);
     }
 
-
     @Override
     public RunningCompleteResponse completeRunning(AuthenticatedUser authUser, RunningCompleteRequest request) {
-        System.out.println("=== completeRunning 시작 ===");
-        System.out.println("SessionId: " + request.getSessionId());
-        System.out.println("UserId: " + authUser.getUserId());
-
         RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
                 .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
 
-        System.out.println("찾은 기록 ID: " + record.getId());
-        System.out.println("기록 소유자 ID: " + record.getUser().getId());
-
-        // 권한 검증
         if (!record.getUser().getId().equals(authUser.getUserId())) {
             throw new IllegalArgumentException("해당 세션에 대한 권한이 없습니다.");
         }
 
         BigDecimal distanceKm = BigDecimal.valueOf(request.getDistanceMeters() / 1000.0);
-        System.out.println("거리(km): " + distanceKm);
 
-        // 완료 처리 전 상태
-        System.out.println("완료 처리 전 - isCompleted: " + record.getIsCompleted());
-        System.out.println("완료 처리 전 - status: " + record.getStatus());
-
-        // 도메인 메서드 사용
         record.complete(
                 distanceKm,
                 request.getDurationSeconds(),
@@ -147,35 +126,20 @@ public class RunningServiceImpl implements RunningService {
                 LocalDateTime.now()
         );
 
-        // 완료 처리 후 상태
-        System.out.println("완료 처리 후 - isCompleted: " + record.getIsCompleted());
-        System.out.println("완료 처리 후 - status: " + record.getStatus());
-
-        // 경로 전체 추가
         if (request.getRoutePoints() != null) {
             request.getRoutePoints().forEach(p ->
                     record.addRoutePoint(p.getLatitude(), p.getLongitude(), p.getSequence())
             );
         }
 
-        // 사용자 통계 업데이트
         User user = record.getUser();
         user.updateRunningStats(distanceKm);
         userRepository.save(user);
 
-        // 저장 후 응답 구성
         RunningRecord savedRecord = runningRecordRepository.save(record);
-        System.out.println("저장된 기록 ID: " + savedRecord.getId());
-        System.out.println("저장된 기록 완료상태: " + savedRecord.getIsCompleted());
-
-        // ✅ 강제 flush
         runningRecordRepository.flush();
-        System.out.println("flush 완료");
 
-        // 엠블럼 자동 지급
         var awardResult = emblemService.scanAndAward(user.getId(), "DISTANCE");
-
-        System.out.println("=== completeRunning 완료 ===");
 
         return new RunningCompleteResponse(
                 savedRecord.getId(),
@@ -190,21 +154,23 @@ public class RunningServiceImpl implements RunningService {
                                 rt.getLatitude(), rt.getLongitude(), rt.getSequence()
                         ))
                         .collect(Collectors.toList()),
-                awardResult
+                awardResult,
+                savedRecord.getRunningType().name(),      // ✅ 추가
+                savedRecord.getVirtualCourseId()          // ✅ 추가
         );
     }
+
     @Override
     public void updateTitle(AuthenticatedUser authUser, Long recordId, RunningTitleUpdateRequest request) {
         RunningRecord record = runningRecordRepository.findById(recordId)
                 .orElseThrow(() -> new IllegalArgumentException("기록을 찾을 수 없습니다."));
 
-        // 소유권 검증
         if (!record.getUser().getId().equals(authUser.getUserId())) {
             throw new IllegalArgumentException("해당 기록에 대한 권한이 없습니다.");
         }
 
         record.setTitle(request.getTitle());
-        runningRecordRepository.save(record); //  저장 추가
+        runningRecordRepository.save(record);
     }
 
     @Override
@@ -213,7 +179,6 @@ public class RunningServiceImpl implements RunningService {
         RunningRecord r = runningRecordRepository.findWithRoutesById(recordId)
                 .orElseThrow(() -> new IllegalArgumentException("기록을 찾을 수 없습니다."));
 
-        // 소유권 검증
         if (!r.getUser().getId().equals(authUser.getUserId())) {
             throw new IllegalArgumentException("해당 기록에 대한 권한이 없습니다.");
         }
@@ -233,7 +198,9 @@ public class RunningServiceImpl implements RunningService {
                                 ))
                                 .collect(Collectors.toList())
                 )
-                .emblemAwardResult(null) // 상세조회에서는 지급 결과 없음
+                .emblemAwardResult(null)
+                .runningType(r.getRunningType().name())   // ✅ 추가
+                .virtualCourseId(r.getVirtualCourseId())  // ✅ 추가
                 .build();
     }
 
@@ -247,56 +214,24 @@ public class RunningServiceImpl implements RunningService {
     @Transactional(readOnly = true)
     @Override
     public Page<RunningRecordSummaryResponse> getRecords(AuthenticatedUser authUser, Pageable pageable) {
-        System.out.println("=== getRecords 시작 ===");
-        System.out.println("요청 사용자 ID: " + authUser.getUserId());
-
         User user = userRepository.findById(authUser.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
-        System.out.println("찾은 사용자: " + user.getId());
-
-        // ✅ 디버깅: 해당 사용자의 모든 기록 확인
-        List<RunningRecord> allRecords = runningRecordRepository.findAll().stream()
-                .filter(r -> r.getUser().getId().equals(user.getId()))
-                .collect(Collectors.toList());
-
-        System.out.println("해당 사용자의 전체 기록 수: " + allRecords.size());
-        allRecords.forEach(r -> {
-            System.out.println("- 기록 ID: " + r.getId() +
-                    ", SessionId: " + r.getSessionId() +
-                    ", 완료여부: " + r.getIsCompleted() +
-                    ", 상태: " + r.getStatus() +
-                    ", 거리: " + r.getDistance());
-        });
-
-        // ✅ 완료된 기록만 필터링해서 확인
-        long completedCount = allRecords.stream()
-                .filter(r -> Boolean.TRUE.equals(r.getIsCompleted()))
-                .count();
-
-        System.out.println("완료된 기록 수: " + completedCount);
 
         Page<RunningRecord> pageResult = runningRecordRepository
                 .findByUserAndIsCompletedTrueOrderByStartedAtDesc(user, pageable);
 
-        System.out.println("페이지 결과 - 총 요소: " + pageResult.getTotalElements());
-        System.out.println("페이지 결과 - 현재 페이지 크기: " + pageResult.getContent().size());
-
-        Page<RunningRecordSummaryResponse> result = pageResult.map(r -> {
-            System.out.println("매핑 중인 기록: " + r.getId());
-            return new RunningRecordSummaryResponse(
-                    r.getId(),
-                    r.getTitle(),
-                    r.getDistance() != null ? r.getDistance().doubleValue() : 0.0,
-                    r.getDuration() != null ? r.getDuration() : 0,
-                    formatPace(r.getAveragePaceSeconds()),
-                    r.getCalories() != null ? r.getCalories() : 0,
-                    r.getStartedAt() != null ? r.getStartedAt().toString() : null
-            );
-        });
-
-        System.out.println("=== getRecords 완료 ===");
-        return result;
+        return pageResult.map(r ->
+                new RunningRecordSummaryResponse(
+                        r.getId(),
+                        r.getTitle(),
+                        r.getDistance() != null ? r.getDistance().doubleValue() : 0.0,
+                        r.getDuration() != null ? r.getDuration() : 0,
+                        formatPace(r.getAveragePaceSeconds()),
+                        r.getCalories() != null ? r.getCalories() : 0,
+                        r.getStartedAt() != null ? r.getStartedAt().toString() : null,
+                        r.getRunningType().name(),     // ✅ 추가
+                        r.getVirtualCourseId()         // ✅ 추가
+                )
+        );
     }
-
 }

--- a/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
@@ -1,7 +1,9 @@
 package com.waytoearth.service.running;
 
 import com.waytoearth.dto.request.running.*;
-import com.waytoearth.dto.response.running.*;
+import com.waytoearth.dto.response.running.RunningCompleteResponse;
+import com.waytoearth.dto.response.running.RunningRecordSummaryResponse;
+import com.waytoearth.dto.response.running.RunningStartResponse;
 import com.waytoearth.entity.RunningRecord;
 import com.waytoearth.entity.User;
 import com.waytoearth.entity.enums.RunningStatus;
@@ -11,12 +13,15 @@ import com.waytoearth.repository.RunningRouteRepository;
 import com.waytoearth.repository.UserRepository;
 import com.waytoearth.security.AuthenticatedUser;
 import com.waytoearth.service.emblem.EmblemService;
-import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -111,17 +116,29 @@ public class RunningServiceImpl implements RunningService {
 
     @Override
     public RunningCompleteResponse completeRunning(AuthenticatedUser authUser, RunningCompleteRequest request) {
+        System.out.println("=== completeRunning 시작 ===");
+        System.out.println("SessionId: " + request.getSessionId());
+        System.out.println("UserId: " + authUser.getUserId());
+
         RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
                 .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
 
-        // 권한 검증 추가
+        System.out.println("찾은 기록 ID: " + record.getId());
+        System.out.println("기록 소유자 ID: " + record.getUser().getId());
+
+        // 권한 검증
         if (!record.getUser().getId().equals(authUser.getUserId())) {
             throw new IllegalArgumentException("해당 세션에 대한 권한이 없습니다.");
         }
 
         BigDecimal distanceKm = BigDecimal.valueOf(request.getDistanceMeters() / 1000.0);
+        System.out.println("거리(km): " + distanceKm);
 
-        // 도메인 메서드 사용: complete(...)
+        // 완료 처리 전 상태
+        System.out.println("완료 처리 전 - isCompleted: " + record.getIsCompleted());
+        System.out.println("완료 처리 전 - status: " + record.getStatus());
+
+        // 도메인 메서드 사용
         record.complete(
                 distanceKm,
                 request.getDurationSeconds(),
@@ -129,6 +146,10 @@ public class RunningServiceImpl implements RunningService {
                 request.getCalories(),
                 LocalDateTime.now()
         );
+
+        // 완료 처리 후 상태
+        System.out.println("완료 처리 후 - isCompleted: " + record.getIsCompleted());
+        System.out.println("완료 처리 후 - status: " + record.getStatus());
 
         // 경로 전체 추가
         if (request.getRoutePoints() != null) {
@@ -143,29 +164,35 @@ public class RunningServiceImpl implements RunningService {
         userRepository.save(user);
 
         // 저장 후 응답 구성
-        runningRecordRepository.save(record);
+        RunningRecord savedRecord = runningRecordRepository.save(record);
+        System.out.println("저장된 기록 ID: " + savedRecord.getId());
+        System.out.println("저장된 기록 완료상태: " + savedRecord.getIsCompleted());
+
+        // ✅ 강제 flush
+        runningRecordRepository.flush();
+        System.out.println("flush 완료");
 
         // 엠블럼 자동 지급
         var awardResult = emblemService.scanAndAward(user.getId(), "DISTANCE");
 
+        System.out.println("=== completeRunning 완료 ===");
+
         return new RunningCompleteResponse(
-                record.getId(),
-                record.getTitle(), // 제목은 PATCH로 수정 가능
-                record.getDistance() != null ? record.getDistance().doubleValue() : 0.0,
-                formatPace(record.getAveragePaceSeconds()),
-                record.getCalories(),
-                record.getStartedAt() != null ? record.getStartedAt().toString() : null,
-                record.getEndedAt() != null ? record.getEndedAt().toString() : null,
-                record.getRoutes().stream()
+                savedRecord.getId(),
+                savedRecord.getTitle(),
+                savedRecord.getDistance() != null ? savedRecord.getDistance().doubleValue() : 0.0,
+                formatPace(savedRecord.getAveragePaceSeconds()),
+                savedRecord.getCalories(),
+                savedRecord.getStartedAt() != null ? savedRecord.getStartedAt().toString() : null,
+                savedRecord.getEndedAt() != null ? savedRecord.getEndedAt().toString() : null,
+                savedRecord.getRoutes().stream()
                         .map(rt -> new RunningCompleteResponse.RoutePoint(
                                 rt.getLatitude(), rt.getLongitude(), rt.getSequence()
                         ))
                         .collect(Collectors.toList()),
                 awardResult
         );
-
     }
-
     @Override
     public void updateTitle(AuthenticatedUser authUser, Long recordId, RunningTitleUpdateRequest request) {
         RunningRecord record = runningRecordRepository.findById(recordId)
@@ -216,4 +243,60 @@ public class RunningServiceImpl implements RunningService {
         int s = paceSeconds % 60;
         return String.format("%02d:%02d", m, s);
     }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<RunningRecordSummaryResponse> getRecords(AuthenticatedUser authUser, Pageable pageable) {
+        System.out.println("=== getRecords 시작 ===");
+        System.out.println("요청 사용자 ID: " + authUser.getUserId());
+
+        User user = userRepository.findById(authUser.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        System.out.println("찾은 사용자: " + user.getId());
+
+        // ✅ 디버깅: 해당 사용자의 모든 기록 확인
+        List<RunningRecord> allRecords = runningRecordRepository.findAll().stream()
+                .filter(r -> r.getUser().getId().equals(user.getId()))
+                .collect(Collectors.toList());
+
+        System.out.println("해당 사용자의 전체 기록 수: " + allRecords.size());
+        allRecords.forEach(r -> {
+            System.out.println("- 기록 ID: " + r.getId() +
+                    ", SessionId: " + r.getSessionId() +
+                    ", 완료여부: " + r.getIsCompleted() +
+                    ", 상태: " + r.getStatus() +
+                    ", 거리: " + r.getDistance());
+        });
+
+        // ✅ 완료된 기록만 필터링해서 확인
+        long completedCount = allRecords.stream()
+                .filter(r -> Boolean.TRUE.equals(r.getIsCompleted()))
+                .count();
+
+        System.out.println("완료된 기록 수: " + completedCount);
+
+        Page<RunningRecord> pageResult = runningRecordRepository
+                .findByUserAndIsCompletedTrueOrderByStartedAtDesc(user, pageable);
+
+        System.out.println("페이지 결과 - 총 요소: " + pageResult.getTotalElements());
+        System.out.println("페이지 결과 - 현재 페이지 크기: " + pageResult.getContent().size());
+
+        Page<RunningRecordSummaryResponse> result = pageResult.map(r -> {
+            System.out.println("매핑 중인 기록: " + r.getId());
+            return new RunningRecordSummaryResponse(
+                    r.getId(),
+                    r.getTitle(),
+                    r.getDistance() != null ? r.getDistance().doubleValue() : 0.0,
+                    r.getDuration() != null ? r.getDuration() : 0,
+                    formatPace(r.getAveragePaceSeconds()),
+                    r.getCalories() != null ? r.getCalories() : 0,
+                    r.getStartedAt() != null ? r.getStartedAt().toString() : null
+            );
+        });
+
+        System.out.println("=== getRecords 완료 ===");
+        return result;
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,15 +62,15 @@ server:
   address: 0.0.0.0
   port: 8080  # 기본 포트는 그대로
 
-### #Profile별 포트 설정
-#---
-#spring:
-#  config:
-#    activate:
-#      on-profile: postman
-#
-#server:
-#  port: 9090  # postman 프로필일 때만 9090 포트 사용
+## #Profile별 포트 설정
+---
+spring:
+  config:
+    activate:
+      on-profile: postman
+
+server:
+  port: 9090  # postman 프로필일 때만 9090 포트 사용
 
 # Swagger 설정
 springdoc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,14 +63,14 @@ server:
   port: 8080  # 기본 포트는 그대로
 
 ## #Profile별 포트 설정
----
-spring:
-  config:
-    activate:
-      on-profile: postman
-
-server:
-  port: 9090  # postman 프로필일 때만 9090 포트 사용
+#---
+#spring:
+#  config:
+#    activate:
+#      on-profile: postman
+#
+#server:
+#  port: 9090  # postman 프로필일 때만 9090 포트 사용
 
 # Swagger 설정
 springdoc:


### PR DESCRIPTION
## 연관 이슈

> \#45

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [x] 기능 추가
* [ ] 기능 삭제
* [x] 버그 수정
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

### PR 내용 요약

* **가상 러닝 API 추가 및 개선**

  * 사용자 가상 코스 등록 API (`POST /v1/user-virtual-courses`)

    * 등록 시 `UserVirtualCourseEntity` 저장 + 세그먼트 진행률 초기화 + `RunningRecord` 자동 생성
    * 응답에 `sessionId` 포함 → 프론트가 이후 업데이트 요청 시 활용 가능

  * 코스 진행률 업데이트 API (`POST /v1/user-virtual-courses/{id}/progress`)

    * 세그먼트별 진행 거리 누적 및 상태(ONGOING → COMPLETED) 갱신
    * `RunningRecord`와 동기화 → 거리, 시간, 칼로리, 페이스, 경로 좌표 반영
    * 코스 전체 거리 도달 시 `status=COMPLETED`로 자동 전환

  * 전체 진행률 조회 API (`GET /v1/user-virtual-courses/{id}/progress`)

    * 사용자 가상 코스의 현재 누적 거리, 진행률 %, 상태 반환

  * 세그먼트별 진행률 조회 API (`GET /v1/user-virtual-courses/{id}/segments/progress`)

    * 세그먼트별 진행 거리 및 상태 반환 → 지도 표시/프론트 시각화에 활용 가능

* **DTO 확장**

  * `UserVirtualCourseResponse` → `sessionId` 필드 추가
  * `VirtualCourseProgressUpdateRequest` → `sessionId`, `durationSeconds`, `averagePaceSeconds`, `calories`, `currentPoint` 확장
  * `VirtualCourseProgressResponse`, `SegmentProgressResponse` 신규 정의

* **엔티티 및 서비스 개선**

  * `RunningRecord`와 가상 코스 진행률을 연계 → 통계 집계 및 지도 기록 조회 가능
  * `User` 엔티티에 누적 거리 업데이트 로직 추가

---

### 테스트 결과

* 사용자 가상 코스 등록 시 DB에 정상 저장 + `sessionId` 응답 확인
* 코스 진행률 업데이트 시 세그먼트와 전체 진행률 모두 누적 반영 확인
* 진행률이 코스 총 거리 이상일 경우 자동으로 `COMPLETED` 상태 전환 확인
* `RunningRecord`와 동기화 → `/v1/running/records` 및 `/v1/running/{recordId}` 조회 시 정상 반영 확인

---

## 리뷰 요구사항 (선택)
