### PR TITLE
feat: Swagger 문서화 개선 및 Mock Login API 추가

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,9 @@
 {
   "permissions": {
     "allow": [
-      "Bash(./gradlew:*)"
+      "Bash(./gradlew:*)",
+      "Bash(jps:*)",
+      "Bash(taskkill:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/main/java/com/waytoearth/config/Swagger/SwaggerConfig.java
+++ b/src/main/java/com/waytoearth/config/Swagger/SwaggerConfig.java
@@ -33,9 +33,17 @@ public class SwaggerConfig {
     }
 
     @Bean
+    public GroupedOpenApi allApi() {
+        return GroupedOpenApi.builder()
+                .group("0. 전체 API")
+                .pathsToMatch("/v1/**")
+                .build();
+    }
+
+    @Bean
     public GroupedOpenApi authApi() {
         return GroupedOpenApi.builder()
-                .group("1. 인증 API")
+                .group("01. 인증 API")
                 .pathsToMatch("/v1/auth/**")
                 .build();
     }
@@ -43,7 +51,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi userApi() {
         return GroupedOpenApi.builder()
-                .group("2. 사용자 API")
+                .group("02. 사용자 API")
                 .pathsToMatch("/v1/users/**")
                 .build();
     }
@@ -51,7 +59,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi runningApi() {
         return GroupedOpenApi.builder()
-                .group("3. 러닝 기록 API")
+                .group("03. 러닝 기록 API")
                 .pathsToMatch("/v1/running/**")
                 .build();
     }
@@ -59,7 +67,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi feedApi() {
         return GroupedOpenApi.builder()
-                .group("4. 피드 API")
+                .group("04. 피드 API")
                 .pathsToMatch("/v1/feeds/**")
                 .build();
     }
@@ -67,7 +75,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi statisticsApi() {
         return GroupedOpenApi.builder()
-                .group("5. 통계 API")
+                .group("05. 통계 API")
                 .pathsToMatch("/v1/statistics/**")
                 .build();
     }
@@ -75,7 +83,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi fileApi() {
         return GroupedOpenApi.builder()
-                .group("6. 파일 업로드 API")
+                .group("06. 파일 업로드 API")
                 .pathsToMatch("/v1/files/**")
                 .build();
     }
@@ -83,7 +91,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi weatherApi() {
         return GroupedOpenApi.builder()
-                .group("7. 날씨 API")
+                .group("07. 날씨 API")
                 .pathsToMatch("/v1/weather/**")
                 .build();
     }
@@ -91,7 +99,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi emblemApi() {
         return GroupedOpenApi.builder()
-                .group("8. 엠블럼 API")
+                .group("08. 엠블럼 API")
                 .pathsToMatch("/v1/emblems/**")
                 .build();
     }
@@ -101,7 +109,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi themeCourseApi() {
         return GroupedOpenApi.builder()
-                .group("9. 테마 코스 API")
+                .group("09. 테마 코스 API")
                 .pathsToMatch("/v1/theme-courses/**")
                 .build();
     }

--- a/src/main/java/com/waytoearth/config/Swagger/SwaggerConfig.java
+++ b/src/main/java/com/waytoearth/config/Swagger/SwaggerConfig.java
@@ -57,33 +57,17 @@ public class SwaggerConfig {
     }
 
     @Bean
-    public GroupedOpenApi virtualCourseApi() {
-        return GroupedOpenApi.builder()
-                .group("4. 가상 코스 API")
-                .pathsToMatch("/v1/virtual-courses/**")
-                .build();
-    }
-
-    @Bean
     public GroupedOpenApi feedApi() {
         return GroupedOpenApi.builder()
-                .group("5. 피드 API")
+                .group("4. 피드 API")
                 .pathsToMatch("/v1/feeds/**")
-                .build();
-    }
-
-    @Bean
-    public GroupedOpenApi crewApi() {
-        return GroupedOpenApi.builder()
-                .group("6. 크루 API")
-                .pathsToMatch("/v1/crews/**")
                 .build();
     }
 
     @Bean
     public GroupedOpenApi statisticsApi() {
         return GroupedOpenApi.builder()
-                .group("7. 통계 API")
+                .group("5. 통계 API")
                 .pathsToMatch("/v1/statistics/**")
                 .build();
     }
@@ -91,7 +75,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi fileApi() {
         return GroupedOpenApi.builder()
-                .group("8. 파일 업로드 API")
+                .group("6. 파일 업로드 API")
                 .pathsToMatch("/v1/files/**")
                 .build();
     }
@@ -99,7 +83,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi weatherApi() {
         return GroupedOpenApi.builder()
-                .group("9. 날씨 API")
+                .group("7. 날씨 API")
                 .pathsToMatch("/v1/weather/**")
                 .build();
     }
@@ -107,7 +91,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi emblemApi() {
         return GroupedOpenApi.builder()
-                .group("10. 엠블럼 API")
+                .group("8. 엠블럼 API")
                 .pathsToMatch("/v1/emblems/**")
                 .build();
     }
@@ -117,7 +101,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi themeCourseApi() {
         return GroupedOpenApi.builder()
-                .group("11. 테마 코스 API")
+                .group("9. 테마 코스 API")
                 .pathsToMatch("/v1/theme-courses/**")
                 .build();
     }
@@ -125,7 +109,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi customCourseApi() {
         return GroupedOpenApi.builder()
-                .group("12. 커스텀 코스 API")
+                .group("10. 커스텀 코스 API")
                 .pathsToMatch("/v1/custom-courses/**")
                 .build();
     }
@@ -133,7 +117,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi courseSegmentApi() {
         return GroupedOpenApi.builder()
-                .group("13. 코스 세그먼트 API")
+                .group("11. 코스 세그먼트 API")
                 .pathsToMatch("/v1/course-segments/**")
                 .build();
     }
@@ -141,7 +125,7 @@ public class SwaggerConfig {
     @Bean
     public GroupedOpenApi userVirtualCourseApi() {
         return GroupedOpenApi.builder()
-                .group("14. 사용자 가상 코스 API")
+                .group("12. 사용자 가상 코스 API")
                 .pathsToMatch("/v1/user-virtual-courses/**")
                 .build();
     }

--- a/src/main/java/com/waytoearth/config/backendtest/SecurityConfigPostman.java
+++ b/src/main/java/com/waytoearth/config/backendtest/SecurityConfigPostman.java
@@ -1,6 +1,6 @@
 package com.waytoearth.config.backendtest;
 
-import com.waytoearth.security.mock.MockAuthFilter;
+import com.waytoearth.config.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,7 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfigPostman {
 
-    private final MockAuthFilter mockAuthFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain postmanFilterChain(HttpSecurity http) throws Exception {
@@ -31,12 +31,12 @@ public class SecurityConfigPostman {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
-                                "/actuator/**", "/health", "/ping"
+                                "/actuator/**", "/health", "/ping",
+                                "/v1/auth/mock-login" // Mock Login API는 인증 불요
                         ).permitAll()
-                        // 컨트롤러에서 @AuthUser를 쓰므로 인증 객체는 필요 -> authenticated()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(mockAuthFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/waytoearth/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/waytoearth/config/jwt/JwtAuthenticationFilter.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 
 @Slf4j
 @Component
-@Profile("!postman")
+// postman 프로파일에서도 JWT 인증 사용하도록 변경
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/waytoearth/controller/v1/Auth/MockAuthController.java
+++ b/src/main/java/com/waytoearth/controller/v1/Auth/MockAuthController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/auth")
 @RequiredArgsConstructor
 @Slf4j
-@Profile("postman")
+@Profile({"postman", "dev"})
 public class MockAuthController {
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/waytoearth/controller/v1/Auth/MockAuthController.java
+++ b/src/main/java/com/waytoearth/controller/v1/Auth/MockAuthController.java
@@ -1,0 +1,59 @@
+package com.waytoearth.controller.v1.Auth;
+
+import com.waytoearth.dto.request.auth.MockLoginRequest;
+import com.waytoearth.dto.response.auth.LoginResponse;
+import com.waytoearth.dto.response.common.ApiResponse;
+import com.waytoearth.service.auth.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Mock 인증 API", description = "테스트용 Mock 로그인 API (postman 프로파일에서만 사용)")
+@RestController
+@RequestMapping("/v1/auth")
+@RequiredArgsConstructor
+@Slf4j
+@Profile("postman")
+public class MockAuthController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    
+    @Operation(
+        summary = "Mock 로그인", 
+        description = "테스트용 Mock 로그인으로 JWT 토큰을 발급받습니다. postman 프로파일에서만 사용 가능합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Mock 로그인 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/mock-login")
+    public ResponseEntity<ApiResponse<LoginResponse>> mockLogin(
+            @Parameter(description = "Mock 로그인 요청", required = true)
+            @RequestBody @Valid MockLoginRequest request) {
+        
+        log.info("[MockAuthController] Mock 로그인 요청 - userId: {}", request.getUserId());
+        
+        // JWT 토큰 발급
+        String jwtToken = jwtTokenProvider.generateToken(request.getUserId());
+        
+        // Mock Login Response 생성
+        LoginResponse response = LoginResponse.builder()
+                .userId(request.getUserId())
+                .jwtToken(jwtToken)
+                .isNewUser(false) // Mock에서는 기존 사용자로 처리
+                .isOnboardingCompleted(true) // Mock에서는 온보딩 완료로 처리
+                .build();
+        
+        log.info("[MockAuthController] Mock 로그인 완료 - userId: {}, tokenGenerated: true", request.getUserId());
+        
+        return ResponseEntity.ok(ApiResponse.success(response, "Mock 로그인에 성공했습니다."));
+    }
+}

--- a/src/main/java/com/waytoearth/controller/v1/Running/RunningController.java
+++ b/src/main/java/com/waytoearth/controller/v1/Running/RunningController.java
@@ -9,6 +9,7 @@ import com.waytoearth.security.AuthUser;
 import com.waytoearth.security.AuthenticatedUser;
 import com.waytoearth.service.running.RunningService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "러닝 기록 API", description = "러닝 시작, 업데이트, 완료 및 기록 조회 관련 API")
 @RestController
 @RequestMapping("/v1/running")
 @RequiredArgsConstructor

--- a/src/main/java/com/waytoearth/controller/v1/User/UserController.java
+++ b/src/main/java/com/waytoearth/controller/v1/User/UserController.java
@@ -7,7 +7,9 @@ import com.waytoearth.dto.response.user.UserSummaryResponse;
 import com.waytoearth.security.AuthenticatedUser;
 import com.waytoearth.security.AuthUser;
 import com.waytoearth.service.user.UserService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class UserController {
     private final UserService userService;
 
 
+    @Operation(summary = "닉네임 중복 확인", description = "닉네임 사용 가능 여부를 확인합니다.")
     @GetMapping("/check-nickname")
     public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkNicknameDuplicate(
             @Parameter(description = "중복 확인할 닉네임", example = "runner_kim", required = true)
@@ -42,10 +45,11 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(data, message));
     }
 
-    /**
-     * 내 정보 전체 조회
-     * GET /v1/users/me
-     */
+    @Operation(
+            summary = "내 정보 전체 조회",
+            description = "현재 로그인한 사용자의 전체 정보를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserInfoResponse>> me(@AuthUser AuthenticatedUser me) {
         log.info("[Users:Me] 내 정보 조회 - userId: {}", me.getUserId());
@@ -53,10 +57,11 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(body, "사용자 정보를 성공적으로 조회했습니다."));
     }
 
-    /**
-     * 내 정보 요약(총거리/횟수/엠블럼/완성도)
-     * GET /v1/users/me/summary
-     */
+    @Operation(
+            summary = "내 정보 요약 조회",
+            description = "총거리, 러닝 횟수, 엠블럼, 완성도 등 요약 정보를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
     @GetMapping("/me/summary")
     public ResponseEntity<ApiResponse<UserSummaryResponse>> summary(@AuthUser AuthenticatedUser me) {
         log.info("[Users:Summary] 요약 조회 - userId: {}", me.getUserId());
@@ -64,11 +69,11 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(body, "사용자 요약 정보를 성공적으로 조회했습니다."));
     }
 
-    /**
-     * 프로필 수정
-     * PUT /v1/users/me
-     * Body: nickname, profile_image_url, residence, weekly_goal_distance(선택/부분 수정)
-     */
+    @Operation(
+            summary = "프로필 수정",
+            description = "닉네임, 프로필 이미지, 거주지, 주간 목표 거리 등을 수정합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
     @PutMapping("/me")
     public ResponseEntity<ApiResponse<Void>> updateProfile(@AuthUser AuthenticatedUser me,
                                                            @Valid @RequestBody UserUpdateRequest request) {

--- a/src/main/java/com/waytoearth/dto/request/auth/MockLoginRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/auth/MockLoginRequest.java
@@ -1,0 +1,20 @@
+package com.waytoearth.dto.request.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "Mock 로그인 요청 (테스트용)")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MockLoginRequest {
+
+    @Schema(description = "테스트할 사용자 ID", example = "1", required = true)
+    @NotNull(message = "사용자 ID는 필수입니다")
+    @Positive(message = "사용자 ID는 양수여야 합니다")
+    private Long userId;
+}

--- a/src/main/java/com/waytoearth/security/mock/MockAuthFilter.java
+++ b/src/main/java/com/waytoearth/security/mock/MockAuthFilter.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Component
-@Profile("postman")
+@Profile("postman-disabled") // 비활성화: postman에서 실제 JWT 토큰 방식 사용
 public class MockAuthFilter extends OncePerRequestFilter {
 
     @Override

--- a/src/test/java/com/waytoearth/testcontroller/PostmanProfileSmokeTest.java
+++ b/src/test/java/com/waytoearth/testcontroller/PostmanProfileSmokeTest.java
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("postman")
+@ActiveProfiles("waytoearth-dev")
 class PostmanProfileSmokeTest {
 
     @Autowired

--- a/src/test/resources/application-postman.yml
+++ b/src/test/resources/application-postman.yml
@@ -2,12 +2,15 @@ spring:
   application:
     name: waytoearth-dev
 
-  # 테스트용 인메모리 H2 데이터베이스
+  config:
+    import: optional:dotenv:.env
+
+  # 테스트용으로도 MariaDB 사용 (H2 호환성 문제 회피)
   datasource:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    username: sa
-    password: 
-    driver-class-name: org.h2.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
 
   # H2 Console (테스트 시 필요하면 활성화)
   h2:
@@ -16,7 +19,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop  # 테스트 시 스키마 자동 생성/삭제
+      ddl-auto: validate  # 기존 스키마 사용 (MariaDB)
     show-sql: false
     properties:
       hibernate:


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #52 

  ## Summary
  - Swagger UI에서 모든 API가 올바르게 표시되도록 개선
  - 개발 환경에서 Mock Login API 사용 가능하도록 설정
  - API 그룹 순서 정렬 및 전체 API 보기 옵션 추가

  ## Changes
  ### Swagger 설정 개선
  - `RunningController`에 누락된 `@Tag` 어노테이션 추가
  - `UserController`의 모든 엔드포인트에 `@Operation` 어노테이션 추가
  - API 그룹 순서 정렬 (01-12번으로 패딩 처리)
  - "0. 전체 API" 그룹 추가로 한 번에 모든 API 조회 가능

  ### Mock Login API 개선
  - `MockAuthController`를 dev 프로필에서도 사용 가능하도록 설정
  - 개발 시 카카오 OAuth 없이도 JWT 토큰 발급 가능

  ### 환경 설정 수정
  - `.env` 파일의 프로필을 `waytoearth-dev` → `dev`로 변경
  - 존재하지 않는 프로필 설정 문제 해결

  ## Test plan
  - [x] Spring Boot 애플리케이션 정상 시작
  - [x] Swagger UI에서 모든 API 그룹 정상 표시 확인
  - [x] "0. 전체 API" 선택 시 모든 API 조회 가능 확인
  - [x] Mock Login API 정상 동작 확인
  - [x] API 그룹 순서 정렬 확인 (01-12 순서)

<img width="510" height="803" alt="image" src="https://github.com/user-attachments/assets/c1dd16a4-9b3e-4091-b92f-3e3476112e9d" />
<img width="474" height="636" alt="image" src="https://github.com/user-attachments/assets/cd199f13-95a2-4bf4-bcba-84e3f638b1cc" />

