### PR TITLE
[FEAT] Feed 좋아요 토글 시 likeCount 불일치 문제 수정

### DIFF
--- a/src/main/java/com/waytoearth/repository/Feed/FeedRepository.java
+++ b/src/main/java/com/waytoearth/repository/Feed/FeedRepository.java
@@ -26,6 +26,10 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositor
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT f FROM Feed f WHERE f.id = :feedId")
     Optional<Feed> findByIdWithLock(@Param("feedId") Long feedId);
+
+    // 최신 좋아요 수만 조회
+    @Query("SELECT f.likeCount FROM Feed f WHERE f.id = :feedId")
+    int getLikeCount(@Param("feedId") Long feedId);
     
     // 원자적 좋아요 증가 (동시성 안전)
     @Modifying


### PR DESCRIPTION
## 연관 이슈

> #20

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [ ] 기능 추가
* [ ] 기능 삭제
* [x] 버그 수정
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

### PR 내용 요약

* **FeedRepository 수정**

`@Query("SELECT f.likeCount FROM Feed f WHERE f.id = :feedId")
  int getLikeCount(@Param("feedId") Long feedId);
`

* **FeedService 수정**

  * 좋아요 토글 시 동시성 문제 방지를 위해 `feedRepository.incrementLikeCount` / `decrementLikeCount` 활용하도록 변경
  * 좋아요 추가/삭제 후 최신 상태 조회 → `FeedLikeResponse` 반환 시 likeCount 값이 정확히 반영되도록 개선

---

### 테스트 결과

* 피드 목록 조회 시 User, RunningRecord, Like 상태가 단일 쿼리로 조회됨 (N+1 발생 X)
* 좋아요 토글 시 `likeCount` 값이 정확하게 증가/감소하며 동시 요청에도 값 불일치 없음 확인

---

## 추가 검토 사항

* 현재는 `원자적 증가/감소` 기반으로 동시성 문제를 해결했는데, 트래픽 급증 상황에서 추가적인 `비관적 락` 적용 여부를 검토할 필요가 있음.

---

