### PR TITLE
feat: BaseTimeEntity 적용 완료 및 관련 코드 수정

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(./gradlew:*)",
       "Bash(jps:*)",
-      "Bash(taskkill:*)"
+      "Bash(taskkill:*)",
+      "Bash(git add:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/main/java/com/waytoearth/entity/Feed/Feed.java
+++ b/src/main/java/com/waytoearth/entity/Feed/Feed.java
@@ -2,10 +2,9 @@ package com.waytoearth.entity.Feed;
 
 import com.waytoearth.entity.Running.RunningRecord;
 import com.waytoearth.entity.User.User;
+import com.waytoearth.entity.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.Instant;
 
 @Entity
 @Table(name = "feeds")
@@ -14,7 +13,7 @@ import java.time.Instant;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Feed {
+public class Feed extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,11 +46,4 @@ public class Feed {
     @Column(name = "version")
     private Long version;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
-
-    @PrePersist
-    public void onCreate() {
-        this.createdAt = Instant.now();
-    }
 }

--- a/src/main/java/com/waytoearth/entity/Running/RunningRecord.java
+++ b/src/main/java/com/waytoearth/entity/Running/RunningRecord.java
@@ -1,6 +1,7 @@
 package com.waytoearth.entity.Running;
 
 import com.waytoearth.entity.User.User;
+import com.waytoearth.entity.common.BaseTimeEntity;
 import com.waytoearth.entity.enums.RunningStatus;
 import com.waytoearth.entity.enums.RunningType;
 import jakarta.persistence.*;
@@ -24,7 +25,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class RunningRecord {
+public class RunningRecord extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/waytoearth/entity/Running/RunningRoute.java
+++ b/src/main/java/com/waytoearth/entity/Running/RunningRoute.java
@@ -1,5 +1,6 @@
 package com.waytoearth.entity.Running;
 
+import com.waytoearth.entity.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -15,7 +16,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class RunningRoute {
+public class RunningRoute extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/waytoearth/entity/User/User.java
+++ b/src/main/java/com/waytoearth/entity/User/User.java
@@ -1,24 +1,20 @@
 package com.waytoearth.entity.User;
 
+import com.waytoearth.entity.common.BaseTimeEntity;
 import com.waytoearth.entity.enums.AgeGroup;
 import com.waytoearth.entity.enums.Gender;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users")
-@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -70,14 +66,6 @@ public class User {
     @Builder.Default
     private Integer totalRunningCount = 0;
 
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @Setter
-    @LastModifiedDate
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 
     // 온보딩 완료 메서드
     public void completeOnboarding(String nickname, String residence, AgeGroup ageGroup,

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/CourseSegmentEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/CourseSegmentEntity.java
@@ -1,5 +1,6 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import com.waytoearth.entity.common.BaseTimeEntity;
 import com.waytoearth.entity.enums.SegmentType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
@@ -13,7 +14,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Schema(description = "코스를 이루는 세그먼트 엔티티")
-public class CourseSegmentEntity {
+public class CourseSegmentEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/CustomCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/CustomCourseEntity.java
@@ -1,10 +1,10 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import com.waytoearth.entity.common.BaseTimeEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -15,7 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Schema(description = "사용자 정의 커스텀 코스 엔티티")
-public class CustomCourseEntity {
+public class CustomCourseEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,8 +31,6 @@ public class CustomCourseEntity {
     @Schema(description = "총 거리 (km)", example = "12.3")
     private Double totalDistanceKm;
 
-    @Schema(description = "생성일시")
-    private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "customCourse", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CourseSegmentEntity> segments;

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentLandmarkEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentLandmarkEntity.java
@@ -1,5 +1,6 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import com.waytoearth.entity.common.BaseTimeEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,7 +13,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Schema(description = "세그먼트 랜드마크 엔티티")
-public class SegmentLandmarkEntity {
+public class SegmentLandmarkEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentProgressEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/SegmentProgressEntity.java
@@ -1,5 +1,6 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import com.waytoearth.entity.common.BaseTimeEntity;
 import com.waytoearth.entity.enums.VirtualCourseStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
@@ -13,7 +14,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Schema(description = "사용자의 세그먼트별 진행률 엔티티")
-public class SegmentProgressEntity {
+public class SegmentProgressEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/ThemeCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/ThemeCourseEntity.java
@@ -1,10 +1,10 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import com.waytoearth.entity.common.BaseTimeEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -15,7 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Schema(description = "운영자 제공 테마 코스 엔티티")
-public class ThemeCourseEntity {
+public class ThemeCourseEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,8 +31,6 @@ public class ThemeCourseEntity {
     @Schema(description = "총 거리 (km)", example = "350.5")
     private Double totalDistanceKm;
 
-    @Schema(description = "생성일시")
-    private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "themeCourse", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CourseSegmentEntity> segments;

--- a/src/main/java/com/waytoearth/entity/VirtualRunning/UserVirtualCourseEntity.java
+++ b/src/main/java/com/waytoearth/entity/VirtualRunning/UserVirtualCourseEntity.java
@@ -1,5 +1,6 @@
 package com.waytoearth.entity.VirtualRunning;
 
+import com.waytoearth.entity.common.BaseTimeEntity;
 import com.waytoearth.entity.enums.VirtualCourseStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
@@ -13,7 +14,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Schema(description = "사용자 가상 코스 진행 상태 엔티티")
-public class UserVirtualCourseEntity {
+public class UserVirtualCourseEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/waytoearth/entity/common/BaseTimeEntity.java
+++ b/src/main/java/com/waytoearth/entity/common/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.waytoearth.entity.common;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/waytoearth/entity/emblem/Emblem.java
+++ b/src/main/java/com/waytoearth/entity/emblem/Emblem.java
@@ -1,18 +1,18 @@
 package com.waytoearth.entity.emblem;
 
+import com.waytoearth.entity.common.BaseTimeEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 
 @Entity
 @Table(name = "emblems")
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor @Builder
 @Schema(description = "엠블럼 정보 엔티티")
-public class Emblem {
+public class Emblem extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,12 +43,4 @@ public class Emblem {
     @Schema(description = "지급 조건 값", example = "100.00")
     private BigDecimal conditionValue; // OPTIONAL (서비스에서 사용)
 
-    @Column(nullable = false, updatable = false)
-    @Schema(description = "생성 시각")
-    private Instant createdAt;
-
-    @PrePersist
-    protected void onCreate() {
-        if (createdAt == null) createdAt = Instant.now();
-    }
 }

--- a/src/main/java/com/waytoearth/entity/emblem/UserEmblem.java
+++ b/src/main/java/com/waytoearth/entity/emblem/UserEmblem.java
@@ -1,11 +1,11 @@
 package com.waytoearth.entity.emblem;
 
 import com.waytoearth.entity.User.User;
+import com.waytoearth.entity.common.BaseTimeEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.Instant;
 
 @Entity
 @Table(
@@ -15,7 +15,7 @@ import java.time.Instant;
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor @Builder
 @Schema(description = "사용자-엠블럼 수집 내역 엔티티")
-public class UserEmblem {
+public class UserEmblem extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,12 +32,4 @@ public class UserEmblem {
     @Schema(description = "보유한 엠블럼")
     private Emblem emblem;
 
-    @Column(nullable = false, updatable = false)
-    @Schema(description = "엠블럼 획득 시각")
-    private Instant acquiredAt;
-
-    @PrePersist
-    protected void onCreate() {
-        if (acquiredAt == null) acquiredAt = Instant.now();
-    }
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #55 

  ## Summary
  • BaseTimeEntity를 모든 엔티티에 적용하고, 기존 시간 관리 코드를 통합 표준화       
  • Emblem, Running 엔티티에 BaseTimeEntity 상속 추가
  • BaseTimeEntity 변경에 따른 서비스 레이어 및 DTO 코드 수정

  ## Changes
  ### Entity 변경사항
  - **Emblem, UserEmblem**: BaseTimeEntity 상속 추가, 기존
  `createdAt`/`acquiredAt` 필드 제거
  - **RunningRecord, RunningRoute**: BaseTimeEntity 상속 추가

  ### 서비스 레이어 수정
  - **EmblemService**: `getAcquiredAt()` → `getCreatedAt()` 메서드 변경 및
  LocalDateTime→Instant 변환 로직 추가
  - **CustomCourseServiceImpl**: 불필요한 수동 `createdAt` 설정 제거

  ### DTO 및 Repository 수정
  - **FeedResponse**: LocalDateTime→Instant 변환 로직 추가
  - **FeedRepositoryImpl**: QueryDSL에서 LocalDateTime→Instant 변환 추가

  ## Test plan
  - [x] 프로젝트 빌드 성공 확인
  - [x] 모든 엔티티 관계 정상 작동 확인
  - [x] 데이터베이스 스키마 자동 업데이트 설정 확인
