### PR TITLE
[FEAT] 카카오 중계서버 방식 제거 및 SDK 로그인 방식 변경 

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/Auth/AuthController.java
+++ b/src/main/java/com/waytoearth/controller/v1/Auth/AuthController.java
@@ -32,10 +32,10 @@ public class AuthController {
     private final AuthService authService;
     private final UserService userService; // 닉네임 중복 확인용
 
-    @Operation(summary = "카카오 로그인", description = "카카오 Authorization Code로 로그인 처리")
+    @Operation(summary = "카카오 로그인", description = "카카오 SDK에서 받은 액세스 토큰으로 로그인 처리")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 인가 코드"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 액세스 토큰"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @PostMapping("/kakao")
@@ -43,9 +43,10 @@ public class AuthController {
             @Parameter(description = "카카오 로그인 요청", required = true)
             @RequestBody @Valid KakaoLoginRequest request) {
 
-        log.info("[AuthController] 카카오 로그인 요청 - authorizationCode: {}", request.getCode());
+        log.info("[AuthController] 카카오 로그인 요청 - accessToken: {}, kakaoId: {}", 
+                request.getAccessToken(), request.getKakaoId());
 
-        LoginResponse response = authService.loginWithKakaoCode(request.getCode());
+        LoginResponse response = authService.loginWithKakaoAccessToken(request);
 
         log.info("[AuthController] 카카오 로그인 완료 - userId: {}, isNewUser: {}",
                 response.getUserId(), response.getIsNewUser());

--- a/src/main/java/com/waytoearth/dto/request/auth/KakaoLoginRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/auth/KakaoLoginRequest.java
@@ -3,17 +3,25 @@ package com.waytoearth.dto.request.auth;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Schema(description = "카카오 로그인 요청")
+@Schema(description = "카카오 로그인 요청 (SDK 방식)")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class KakaoLoginRequest {
 
-    @Schema(description = "카카오 인가 코드", example = "abc123xyz", required = true)
-    @NotBlank(message = "인가 코드는 필수입니다")
-    private String code;
+    @Schema(description = "카카오 액세스 토큰", example = "aaaa1111bbbb2222", required = true)
+    @NotBlank(message = "액세스 토큰은 필수입니다")
+    private String accessToken;
+
+    @Schema(description = "카카오 사용자 ID", example = "1234567890", required = true) 
+    @NotNull(message = "카카오 사용자 ID는 필수입니다")
+    private String kakaoId;
+
+    @Schema(description = "모바일 여부", example = "true")
+    private Boolean isMobile;
 }

--- a/src/main/java/com/waytoearth/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/feed/FeedResponse.java
@@ -4,7 +4,7 @@ import com.waytoearth.entity.Feed.Feed;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 @Schema(description = "피드 응답 DTO")
 @Builder
@@ -24,8 +24,8 @@ public record FeedResponse(
         @Schema(description = "현재 로그인한 사용자가 좋아요 눌렀는지 여부", example = "true")
         boolean liked,   // 새로 추가됨
 
-        @Schema(description = "작성 시간", example = "2025-08-18T02:45:00Z")
-        Instant createdAt,
+        @Schema(description = "작성 시간", example = "2025-08-18T02:45:00")
+        LocalDateTime createdAt,
 
         @Schema(description = "작성자 ID", example = "7")
         Long userId,

--- a/src/main/java/com/waytoearth/entity/Feed/Feed.java
+++ b/src/main/java/com/waytoearth/entity/Feed/Feed.java
@@ -40,6 +40,7 @@ public class Feed extends BaseTimeEntity {
     private String imageKey;
 
     @Column(name = "like_count", nullable = false)
+    @Builder.Default
     private int likeCount = 0;
 
     @Version

--- a/src/main/java/com/waytoearth/entity/emblem/UserEmblem.java
+++ b/src/main/java/com/waytoearth/entity/emblem/UserEmblem.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.Instant;
+
 
 @Entity
 @Table(
@@ -31,5 +33,9 @@ public class UserEmblem extends BaseTimeEntity {
     @JoinColumn(name = "emblem_id", nullable = false)
     @Schema(description = "보유한 엠블럼")
     private Emblem emblem;
+
+    @Column(name = "acquired_at")
+    @Schema(description = "엠블럼 획득 시각", example = "2024-01-15T10:30:00Z")
+    private Instant acquiredAt;
 
 }

--- a/src/main/java/com/waytoearth/repository/Feed/FeedRepositoryImpl.java
+++ b/src/main/java/com/waytoearth/repository/Feed/FeedRepositoryImpl.java
@@ -66,7 +66,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                         .averagePace(formatPace(tuple.get(runningRecord.averagePaceSeconds)))
                         .calories(tuple.get(runningRecord.calories))
                         .build())
-                .toList();
+                .collect(java.util.stream.Collectors.toList());
     }
 
     private String formatPace(Integer paceSeconds) {

--- a/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/VirtualRunning/CustomCourseServiceImpl.java
@@ -30,7 +30,6 @@ public class CustomCourseServiceImpl implements CustomCourseService {
                 .totalDistanceKm(request.getSegments().stream()
                         .mapToDouble(CourseSegmentCreateRequest::getDistanceKm)
                         .sum())
-                .createdAt(LocalDateTime.now())
                 .build();
 
         // ✅ 세그먼트 생성 및 course와 연관관계 주입

--- a/src/main/java/com/waytoearth/service/auth/AuthService.java
+++ b/src/main/java/com/waytoearth/service/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.waytoearth.service.auth;
 
+import com.waytoearth.dto.request.auth.KakaoLoginRequest;
 import com.waytoearth.dto.request.auth.OnboardingRequest;
 import com.waytoearth.dto.response.auth.KakaoUserInfo;
 import com.waytoearth.dto.response.auth.LoginResponse;
@@ -22,19 +23,27 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
 
     /**
-     * 카카오 Authorization Code로 로그인 처리
+     * 카카오 SDK 액세스 토큰으로 로그인 처리
      */
     @Transactional
-    public LoginResponse loginWithKakaoCode(String authorizationCode) {
-        log.info("[AuthService] 카카오 로그인 시작 - authorizationCode: {}", authorizationCode);
+    public LoginResponse loginWithKakaoAccessToken(KakaoLoginRequest request) {
+        log.info("[AuthService] 카카오 로그인 시작 - kakaoId: {}", request.getKakaoId());
 
-        // 1. 카카오에서 Access Token 발급
-        String kakaoAccessToken = kakaoApiService.getKakaoAccessToken(authorizationCode);
-        log.info("[AuthService] 카카오 액세스 토큰 발급 완료");
-
-        // 2. 카카오에서 사용자 정보 조회
-        KakaoUserInfo kakaoUserInfo = kakaoApiService.getKakaoUserInfo(kakaoAccessToken);
+        // 1. 카카오 액세스 토큰으로 사용자 정보 조회 및 검증
+        KakaoUserInfo kakaoUserInfo = kakaoApiService.verifyAndGetKakaoUserInfo(request.getAccessToken());
         log.info("[AuthService] 카카오 사용자 정보 조회 완료 - kakaoId: {}", kakaoUserInfo.getId());
+
+        // 2. 토큰에서 가져온 사용자 ID와 요청의 사용자 ID 일치 여부 확인 (보안)
+        // 2. 토큰에서 가져온 사용자 ID와 요청의 사용자 ID 일치 여부 확인 (보안)
+        String tokenUserId = String.valueOf(kakaoUserInfo.getId());
+        String requestUserId = String.valueOf(request.getKakaoId());
+
+        if (!tokenUserId.equals(requestUserId)) {
+            log.warn("[AuthService] 카카오 사용자 ID 불일치 - token: {}, request: {}",
+                    tokenUserId, requestUserId);
+            throw new IllegalArgumentException("토큰과 사용자 ID가 일치하지 않습니다");
+        }
+
 
         // 3. 기존 사용자 조회 또는 신규 생성
         User existingUser = userService.findByKakaoId(kakaoUserInfo.getId());

--- a/src/main/java/com/waytoearth/service/auth/KakaoApiService.java
+++ b/src/main/java/com/waytoearth/service/auth/KakaoApiService.java
@@ -99,6 +99,36 @@ public class KakaoApiService {
         }
     }
 
+    /**
+     * SDK용: 카카오 액세스 토큰 검증 및 사용자 정보 조회
+     * (getKakaoUserInfo와 동일하지만 SDK 용도임을 명시)
+     */
+    public KakaoUserInfo verifyAndGetKakaoUserInfo(String accessToken) {
+        log.info("[KakaoApiService] SDK 토큰 검증 및 사용자 정보 조회 시작");
+
+        try {
+            KakaoUserInfo kakaoUserInfo = kakaoApiWebClient.get()
+                    .uri("/v2/user/me")
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfo.class)
+                    .block();
+
+            Objects.requireNonNull(kakaoUserInfo, "카카오 사용자 정보 응답이 null입니다");
+
+            log.info("[KakaoApiService] SDK 토큰 검증 성공 - kakaoId: {}", kakaoUserInfo.getId());
+            return kakaoUserInfo;
+
+        } catch (WebClientResponseException e) {
+            log.error("[KakaoApiService] SDK 토큰 검증 실패 - Status: {}, Body: {}",
+                    e.getStatusCode(), e.getResponseBodyAsString());
+            throw new UnauthorizedException("카카오 액세스 토큰이 유효하지 않습니다", e);
+        } catch (Exception e) {
+            log.error("[KakaoApiService] SDK 토큰 검증 중 예상치 못한 에러", e);
+            throw new RuntimeException("카카오 토큰 검증 중 오류가 발생했습니다.", e);
+        }
+    }
+
     // 카카오 API 응답용 내부 DTO
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
@@ -235,3 +235,4 @@ public class RunningServiceImpl implements RunningService {
         );
     }
 }
+


### PR DESCRIPTION
좋습니다 👍 제가 주신 예시 템플릿을 그대로 활용해서, **"ngrok 중계 서버 기반 카카오 로그인 → 카카오 SDK 기반 로그인 방식으로 변경"** 작업에 맞는 PR 템플릿을 작성해드릴게요.

---

## 연관 이슈

> \#20

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [ ] 기능 추가
* [ ] 기능 삭제
* [x] 버그 수정
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

### PR 내용 요약

* **AuthController 수정**

  * 기존: 카카오 Authorization Code 기반 로그인 처리
  * 변경: 카카오 SDK에서 발급받은 **Access Token 기반 로그인 처리**로 변경

* **KakaoLoginRequest 수정**

  * `code` 필드 제거 → `accessToken`, `kakaoId`, `isMobile` 필드 중심으로 구조 변경

* **AuthService 수정**

  * `loginWithKakaoCode` → `loginWithKakaoAccessToken` 메서드로 변경
  * 토큰에서 조회한 kakaoId와 요청의 kakaoId 일치 여부 검증 로직 추가

* **KakaoApiService 수정**

  * `verifyAndGetKakaoUserInfo` 메서드 추가 → SDK에서 발급받은 Access Token을 이용해 사용자 정보 검증

* **Feed, UserEmblem 등 부가적인 수정**

  * Feed 엔티티 `likeCount` 기본값 추가
  * UserEmblem 엔티티에 `acquiredAt` 필드 추가
  * Repository 쿼리 스트림 처리 개선 (`.toList()` → `Collectors.toList()`)

---

### 테스트 결과

* **카카오 SDK 기반 로그인 정상 동작 확인**

  * React Native SDK에서 발급받은 Access Token 전달 시, 서버에서 정상 검증 및 사용자 정보 조회 완료
  * 신규 사용자 → DB 저장 후 JWT 발급
  * 기존 사용자 → 온보딩 여부 확인 후 JWT 발급

* **추가 검증**

  * Kakao SDK 키 해시 등록 완료 → Android 환경에서 keyHash 불일치 문제 해결됨
  * 모바일 환경에서 `Network Error` 발생하지 않고 정상적으로 JWT 반환됨

---

## 추가 검토 사항

* 현재는 **SDK Access Token 직접 검증 방식**으로 동작

  * 장점: 프론트-백 간 인증 플로우 단순화, ngrok 기반 중계 서버 불필요
 
* 추후 카카오 리프레시 토큰 저장 및 자동 재발급 로직을 추가할 필요가 있음

