### PR TITLE
[feat]  Get presign url 발급 메소드

### DIFF
--- a/src/main/java/com/waytoearth/dto/response/file/PresignResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/file/PresignResponse.java
@@ -15,10 +15,10 @@ public class PresignResponse {
     @Schema(description = "업로드용 Presigned URL")
     private String uploadUrl;
 
-    @Schema(description = "업로드 후 접근 가능한 공개 URL")
-    private String publicUrl;
+    @Schema(description = "다운로드용 Presigned URL")
+    private String downloadUrl;
 
-    @Schema(description = "S3 오브젝트 키", example = "profiles/12345.png")
+    @Schema(description = "S3 오브젝트 키", example = "profiles/12345/profile.png")
     private String key;
 
     @Schema(description = "만료 시간(초)", example = "300")
@@ -26,11 +26,10 @@ public class PresignResponse {
 
     public PresignResponse() { }
 
-    public PresignResponse(String uploadUrl, String publicUrl, String key, int expiresIn) {
+    public PresignResponse(String uploadUrl, String downloadUrl, String key, int expiresIn) {
         this.uploadUrl = uploadUrl;
-        this.publicUrl = publicUrl;
+        this.downloadUrl = downloadUrl;
         this.key = key;
         this.expiresIn = expiresIn;
     }
-
 }

--- a/src/main/java/com/waytoearth/service/file/FileService.java
+++ b/src/main/java/com/waytoearth/service/file/FileService.java
@@ -10,8 +10,10 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 import java.net.URL;
 import java.time.Duration;
@@ -24,42 +26,66 @@ import java.util.UUID;
 @Slf4j
 public class FileService {
 
-    private static final long MAX_SIZE = 5L * 1024 * 1024; // 5MB
+    private static final long MAX_PROFILE_SIZE = 5L * 1024 * 1024; // 5MB
+    private static final long MAX_FEED_SIZE = 10L * 1024 * 1024;   // 10MB
     private static final Duration EXPIRES_IN = Duration.ofMinutes(5);
 
     private final S3Presigner presigner;
 
-    @Value("${cloud.aws.s3.bucket}") private String bucket;
-    @Value("${cloud.aws.region}")    private String region;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
 
-    //  프로필 이미지 Presign
+    @Value("${cloud.aws.region}")
+    private String region;
+
+    // 프로필 Presign 발급
     public PresignResponse presignProfile(Long userId, PresignRequest req) {
-        if (userId == null || userId <= 0) throw new IllegalArgumentException("유효하지 않은 사용자 ID");
-        if (req == null) throw new IllegalArgumentException("요청이 비어 있습니다.");
+        validateProfile(userId, req);
 
-        final String contentType = safeLower(req.getContentType());
-        final long size = req.getSize();
-
-        if (contentType == null || !contentType.matches("^image/(jpeg|png|webp)$"))
-            throw new IllegalArgumentException("허용되지 않는 Content-Type");
-        if (size <= 0 || size > MAX_SIZE)
-            throw new IllegalArgumentException("파일 크기 초과(최대 5MB)");
-
-        final String ext = switch (contentType) {
+        final String ext = switch (req.getContentType().toLowerCase(Locale.ROOT)) {
             case "image/jpeg" -> "jpg";
             case "image/png"  -> "png";
             case "image/webp" -> "webp";
             default -> "bin";
         };
 
-        //  항상 userId 기반 고정 key 사용 → 중복 방지
         String key = String.format("profiles/%d/profile.%s", userId, ext);
 
+        String uploadUrl = createPresignedPutUrl(key, req.getContentType());
+        String downloadUrl = createPresignedGetUrl(key);
+
+        log.info("[S3 Presign Profile] userId={}, key={}, uploadUrl={}, downloadUrl={}",
+                userId, key, uploadUrl, downloadUrl);
+
+        return new PresignResponse(uploadUrl, downloadUrl, key, (int) EXPIRES_IN.getSeconds());
+    }
+
+    // 피드 Presign 발급
+    public PresignResponse presignFeed(Long userId, PresignRequest req) {
+        if (!req.getContentType().matches("^image/(jpeg|png|webp)$")) {
+            throw new IllegalArgumentException("허용되지 않는 Content-Type");
+        }
+        if (req.getSize() > MAX_FEED_SIZE) {
+            throw new IllegalArgumentException("파일 용량 초과 (최대 10MB)");
+        }
+
+        String key = String.format("feeds/%s/%s/%s", LocalDate.now(), userId, UUID.randomUUID());
+
+        String uploadUrl = createPresignedPutUrl(key, req.getContentType());
+        String downloadUrl = createPresignedGetUrl(key);
+
+        log.info("[S3 Presign Feed] userId={}, key={}, uploadUrl={}, downloadUrl={}",
+                userId, key, uploadUrl, downloadUrl);
+
+        return new PresignResponse(uploadUrl, downloadUrl, key, (int) EXPIRES_IN.getSeconds());
+    }
+
+    // 공통 Presign PUT
+    private String createPresignedPutUrl(String key, String contentType) {
         PutObjectRequest put = PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)
                 .contentType(contentType)
-//                .contentLength(size)
                 .build();
 
         PutObjectPresignRequest presignReq = PutObjectPresignRequest.builder()
@@ -67,47 +93,27 @@ public class FileService {
                 .signatureDuration(EXPIRES_IN)
                 .build();
 
-        URL signedUrl = presigner.presignPutObject(presignReq).url();
-
-        String publicUrl = String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
-
-        log.info("[S3 Presign Profile] bucket={}, region={}, userId={}, key={}, uploadUrl={}, publicUrl={}",
-                bucket, region, userId, key, signedUrl, publicUrl);
-
-        return new PresignResponse(signedUrl.toString(), publicUrl, key, (int) EXPIRES_IN.getSeconds());
+        URL url = presigner.presignPutObject(presignReq).url();
+        return url.toString();
     }
 
-    //  피드 이미지 Presign
-    public PresignResponse presignFeed(Long userId, PresignRequest req) {
-        if (!req.getContentType().matches("^image/(jpeg|png|webp)$"))
-            throw new IllegalArgumentException("허용되지 않는 Content-Type");
-        if (req.getSize() > 10 * 1024 * 1024)
-            throw new IllegalArgumentException("파일 용량 초과 (최대 10MB)");
-
-        String key = String.format("feeds/%s/%s/%s", LocalDate.now(), userId, UUID.randomUUID());
-
-        PutObjectRequest objectRequest = PutObjectRequest.builder()
+    // 공통 Presign GET
+    private String createPresignedGetUrl(String key) {
+        GetObjectRequest get = GetObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)
-                .contentType(req.getContentType())
                 .build();
 
-        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+        GetObjectPresignRequest presignReq = GetObjectPresignRequest.builder()
+                .getObjectRequest(get)
                 .signatureDuration(EXPIRES_IN)
-                .putObjectRequest(objectRequest)
                 .build();
 
-        URL url = presigner.presignPutObject(presignRequest).url();
-
-        return new PresignResponse(
-                url.toString(),
-                String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key),
-                key,
-                (int) EXPIRES_IN.getSeconds()
-        );
+        URL url = presigner.presignGetObject(presignReq).url();
+        return url.toString();
     }
 
-    //  S3 삭제
+    // S3 삭제
     public void deleteObject(String key) {
         if (key == null || key.isBlank()) return;
         try (S3Client s3 = S3Client.builder().region(Region.of(region)).build()) {
@@ -119,7 +125,18 @@ public class FileService {
         }
     }
 
-    private static String safeLower(String v) {
-        return v == null ? null : v.toLowerCase(Locale.ROOT).trim();
+    private void validateProfile(Long userId, PresignRequest req) {
+        if (userId == null || userId <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 사용자 ID");
+        }
+        if (req == null) {
+            throw new IllegalArgumentException("요청이 비어 있습니다.");
+        }
+        if (req.getContentType() == null || !req.getContentType().matches("^image/(jpeg|png|webp)$")) {
+            throw new IllegalArgumentException("허용되지 않는 Content-Type");
+        }
+        if (req.getSize() <= 0 || req.getSize() > MAX_PROFILE_SIZE) {
+            throw new IllegalArgumentException("파일 크기 초과(최대 5MB)");
+        }
     }
 }


### PR DESCRIPTION


##  연관 이슈

---

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

* [x] 기능 추가
* [ ] 기능 삭제
* [x] 버그 수정
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

### PR 내용 요약

* **S3 Presign 리팩토링**

  * 기존 `publicUrl` 제거 → `downloadUrl`(GET presign) 추가
  * 업로드 후 접근 시 **private 버킷에서도 정상 조회 가능**
  * `PresignResponse` DTO 필드 변경: `uploadUrl`, `downloadUrl`, `key`, `expiresIn`
  * `FileService`:

    * 공통 메서드 `createPresignedPutUrl`, `createPresignedGetUrl` 분리
    * 프로필/피드 Presign 모두 업로드 + 다운로드 URL 반환
  * 로그에 `uploadUrl`, `downloadUrl` 함께 출력하도록 수정

---

### 테스트 결과 or 스크린샷

* Presign 발급 API 호출 → `uploadUrl`, `downloadUrl` 확인
* `uploadUrl`로 PUT 요청 후, `downloadUrl`로 GET 요청 시 정상 동작 확인 (`AccessDenied` 발생하지 않음)

---

###  리뷰 요구사항 (선택)

* `expiresIn` 기본값(5분)을 더 늘릴지 여부 (예: 1시간)
* 프로필 이미지와 피드 이미지의 presign 정책을 동일하게 가져가도 되는지 확인 필요
