### PR TITLE
feat : sockjs 호환 문제 해결

### DIFF
--- a/WEBSOCKET_AUTH_GUIDE.md
+++ b/WEBSOCKET_AUTH_GUIDE.md
@@ -1,23 +1,37 @@
-# WebSocket 인증 가이드
+# WebSocket 연결 가이드
+
+## 🔗 연결 엔드포인트
+
+### ✅ **방법 1: 순수 WebSocket (권장)**
+```javascript
+// 순수 WebSocket 연결
+const ws = new WebSocket('ws://your-server.com/ws/crew/123/chat');
+// 헤더에서 토큰 전송 (서버에서 Authorization 헤더 확인)
+```
+
+### ✅ **방법 2: SockJS (백업용)**
+```javascript
+// SockJS 연결
+const socket = new SockJS('http://your-server.com/sockjs/crew/123/chat');
+// 프로토콜에서 토큰 전송
+```
 
 ## 🔒 보안 토큰 전송 방법
 
-### ✅ **권장 방법 1: Authorization 헤더 사용**
-
+### ✅ **순수 WebSocket - Authorization 헤더**
 ```javascript
-// JavaScript WebSocket 연결
-const ws = new WebSocket('ws://localhost:8080/ws/crew/123/chat', [], {
+// React Native / Node.js
+const ws = new WebSocket('ws://your-server.com/ws/crew/123/chat', [], {
     headers: {
         'Authorization': 'Bearer ' + yourJwtToken
     }
 });
 ```
 
-### ✅ **권장 방법 2: Sec-WebSocket-Protocol 헤더 사용 (SockJS 호환)**
-
+### ✅ **SockJS - Protocol 헤더**
 ```javascript
-// SockJS 연결 시
-const socket = new SockJS('/ws/crew/123/chat', [], {
+// 브라우저에서 SockJS
+const socket = new SockJS('http://your-server.com/sockjs/crew/123/chat', null, {
     protocols_whitelist: ['Bearer.' + yourJwtToken]
 });
 ```

--- a/src/main/java/com/waytoearth/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/waytoearth/config/websocket/WebSocketConfig.java
@@ -20,7 +20,13 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        // 순수 WebSocket 연결 (권장)
         registry.addHandler(crewChatWebSocketHandler, "/ws/crew/{crewId}/chat")
+                .addInterceptors(webSocketAuthInterceptor)
+                .setAllowedOriginPatterns(allowedOrigins.split(","));
+
+        // SockJS 연결 (백업용)
+        registry.addHandler(crewChatWebSocketHandler, "/sockjs/crew/{crewId}/chat")
                 .addInterceptors(webSocketAuthInterceptor)
                 .setAllowedOriginPatterns(allowedOrigins.split(","))
                 .withSockJS()


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트


> 이번 PR에서 작업한 내용을 간략히 설명해주세요

WebSocket 404 에러 해결

   문제 및 해결

  문제: SockJS와 순수 WebSocket이 같은 경로를 사용해서 경로 충돌 발생
  - 에러: Invalid SockJS path '/1/chat' - required to have 3 segments

  해결:
  1. 순수 WebSocket: /ws/crew/{crewId}/chat (권장)
  2. SockJS: /sockjs/crew/{crewId}/chat (백업용)



### 테스트 결과 or 스크린샷 (선택)
> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요