### PR TITLE
fix: Redis 랭킹 시스템 성능 및 안정성 개선

### DIFF
--- a/src/main/java/com/waytoearth/repository/crew/CrewRepository.java
+++ b/src/main/java/com/waytoearth/repository/crew/CrewRepository.java
@@ -79,6 +79,10 @@ public interface CrewRepository extends JpaRepository<CrewEntity, Long> {
     /**
      * 페이징 지원 메서드들
      */
+    @Query("SELECT c FROM CrewEntity c " +
+           "JOIN FETCH c.owner " +
+           "WHERE c.isActive = true " +
+           "ORDER BY c.createdAt DESC")
     Page<CrewEntity> findByIsActiveTrueOrderByCreatedAtDesc(Pageable pageable);
 
     //페이징 지원 크루 검색 - N+1 방지

--- a/src/main/java/com/waytoearth/service/ranking/CrewRankingService.java
+++ b/src/main/java/com/waytoearth/service/ranking/CrewRankingService.java
@@ -33,6 +33,26 @@ public interface CrewRankingService {
     void updateCrewRanking(Long crewId, String month, Double newTotalDistance);
 
     /**
+     * 멤버 러닝 횟수 업데이트 (원자적 증가)
+     */
+    void incrementMemberRunCount(Long crewId, Long userId, String month);
+
+    /**
+     * 크루 러닝 횟수 업데이트 (원자적 증가)
+     */
+    void incrementCrewRunCount(Long crewId, String month);
+
+    /**
+     * 멤버 러닝 횟수 조회
+     */
+    Integer getMemberRunCount(Long crewId, Long userId, String month);
+
+    /**
+     * 크루 러닝 횟수 조회
+     */
+    Integer getCrewRunCount(Long crewId, String month);
+
+    /**
      * DB 데이터로 Redis 랭킹 재구축
      */
     void rebuildRankingFromDB(String month);

--- a/src/main/java/com/waytoearth/service/ranking/CrewRankingServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/ranking/CrewRankingServiceImpl.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Slf4j
@@ -154,11 +156,11 @@ public class CrewRankingServiceImpl implements CrewRankingService {
             .toList();
 
         List<User> users = userRepository.findAllById(userIds);
-        java.util.Map<Long, String> userNicknameMap = users.stream()
+        Map<Long, String> userNicknameMap = users.stream()
             .collect(java.util.stream.Collectors.toMap(User::getId, User::getNickname));
 
         // Redis에서 러닝 횟수 조회
-        java.util.Map<Long, Integer> runCountMap = new java.util.HashMap<>();
+        Map<Long, Integer> runCountMap = new HashMap<>();
         for (Long userId : userIds) {
             runCountMap.put(userId, getMemberRunCount(crewId, userId, month));
         }
@@ -197,11 +199,11 @@ public class CrewRankingServiceImpl implements CrewRankingService {
             .toList();
 
         List<CrewEntity> crews = crewRepository.findAllById(crewIds);
-        java.util.Map<Long, String> crewNameMap = crews.stream()
+        Map<Long, String> crewNameMap = crews.stream()
             .collect(java.util.stream.Collectors.toMap(CrewEntity::getId, CrewEntity::getName));
 
         // Redis에서 러닝 횟수 조회
-        java.util.Map<Long, Integer> runCountMap = new java.util.HashMap<>();
+        Map<Long, Integer> runCountMap = new HashMap<>();
         for (Long crewId : crewIds) {
             runCountMap.put(crewId, getCrewRunCount(crewId, month));
         }

--- a/src/main/java/com/waytoearth/util/RankingKeyUtil.java
+++ b/src/main/java/com/waytoearth/util/RankingKeyUtil.java
@@ -34,4 +34,23 @@ public class RankingKeyUtil {
     public static String monthlyRankingPattern(String month) {
         return RANKING_PREFIX + "*:" + month;
     }
+
+    /**
+     * 크루 멤버 러닝 횟수 저장 키 (Hash)
+     * @param crewId 크루 ID
+     * @param month 월 (YYYY-MM)
+     * @return Redis key (예: waytoearth:ranking:runcount:member:123:2024-03)
+     */
+    public static String memberRunCountKey(Long crewId, String month) {
+        return RANKING_PREFIX + "runcount:member:" + crewId + ":" + month;
+    }
+
+    /**
+     * 크루 전체 러닝 횟수 저장 키 (Hash)
+     * @param month 월 (YYYY-MM)
+     * @return Redis key (예: waytoearth:ranking:runcount:crew:2024-03)
+     */
+    public static String crewRunCountKey(String month) {
+        return RANKING_PREFIX + "runcount:crew:" + month;
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #71 

  Summary

  - Redis 랭킹 시스템의 성능 및 안정성 개선
  - N+1 쿼리 문제 해결로 데이터베이스 부하 감소
  - 크루 목록 조회 500 에러 수정
  - 러닝 횟수(runCount) Redis 저장 기능 추가
  - Redis 업데이트 실패 시 자동 재시도 로직 추가

  Changes

  🐛 Bug Fixes

  - 크루 목록 조회 시 LazyInitializationException 발생 수정 (owner JOIN FETCH        
  추가)
  - Map import 누락으로 인한 컴파일 이슈 해결

  ⚡ Performance Improvements

  - N+1 쿼리 문제 해결: 랭킹 조회 시 사용자/크루 정보를 배치로 조회하도록 개선       
    - userRepository.findById() 루프 호출 → findAllById() 일괄 조회
    - crewRepository.findById() 루프 호출 → findAllById() 일괄 조회
  - 크루 랭킹 조회 시 크루명을 실제 DB에서 조회하도록 변경 (하드코딩 제거)

  ✨ New Features

  - Redis에 러닝 횟수(runCount) 저장
    - Hash 구조로 멤버/크루별 러닝 횟수 관리
    - 원자적 증가 연산으로 동시성 안전 보장
    - 랭킹 조회 시 runCount 함께 반환

  🔧 Improvements

  - Redis 업데이트 실패 처리 개선
    - @Retryable 적용으로 최대 3번 자동 재시도 (200ms, 400ms, 800ms 간격)
    - 실패 시에도 메인 로직에 영향 없도록 예외 처리
  - Redis 랭킹 동시성 문제 주석으로 명시 (DB를 source of truth로 관리)

  Test Plan

  - 크루 목록 조회 API 테스트 (GET /v1/crews)
  - 크루 랭킹 조회 API 테스트 (GET /v1/crews/statistics/rankings/distance)
  - 크루 내 멤버 랭킹 조회 API 테스트 (GET
  /v1/crews/statistics/{crewId}/members/ranking)
  - runCount가 응답에 포함되는지 확인
  - Redis 장애 시나리오 테스트 (재시도 로직 동작 확인)

  Files Changed

  - CrewRepository.java - owner JOIN FETCH 추가
  - CrewStatisticsServiceImpl.java - Redis 재시도, runCount 증가 호출
  - CrewRankingServiceImpl.java - N+1 해결, runCount 구현, 크루명 조회
  - CrewRankingService.java - runCount 메서드 추가
  - RankingKeyUtil.java - runCount 키 생성 메서드 추가
