### PR TITLE
fix: 크루 통계 연동 버그 수정

### DIFF
--- a/src/main/java/com/waytoearth/repository/crew/CrewMemberRepository.java
+++ b/src/main/java/com/waytoearth/repository/crew/CrewMemberRepository.java
@@ -28,6 +28,13 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
 
     List<CrewMemberEntity> findByUserAndIsActiveTrueOrderByJoinedAtDesc(User user);
 
+    // userId로 활성 크루 조회 (크루 정보 포함, 통계 업데이트용)
+    @Query("SELECT cm FROM CrewMemberEntity cm " +
+           "JOIN FETCH cm.crew " +
+           "WHERE cm.user.id = :userId AND cm.isActive = true " +
+           "ORDER BY cm.joinedAt DESC")
+    List<CrewMemberEntity> findByUserIdWithCrew(@Param("userId") Long userId);
+
     boolean existsByCrewAndUserAndIsActiveTrue(CrewEntity crew, User user);
 
     long countByCrewAndIsActiveTrue(CrewEntity crew);


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #81

  ### 문제 설명
  러닝 완료 시 개인 통계는 정상 업데이트되지만, 크루 통계가 전혀 업데이트되지 않는 치명적인 버그가 발견.

  #### 영향 범위
  - ❌ 크루 월간 통계 (총 거리, 러닝 횟수) 업데이트 안 됨
  - ❌ 크루 랭킹 시스템 작동 안 됨
  - ❌ 크루 MVP 선정 안 됨
  - ❌ Redis 랭킹 캐시 업데이트 안 됨
  - **결론: 크루 기능이 사실상 작동하지 않음**

  ---

  ### 원인 분석

  `RunningServiceImpl.completeRunning()` 메서드에서:
  ```java
  // ✅ 개인 통계 업데이트
  user.updateRunningStats(distanceKm);

  // ✅ 엠블럼 자동 지급
  emblemService.scanAndAward(user.getId(), "DISTANCE");

  // ❌ 크루 통계 업데이트 호출이 누락됨!

  CrewStatisticsService.updateStatisticsAfterRun() 메서드는 이미 구현되어 있었으나, 러닝 완료 시 호출되지 않았습니다.

  ---
  해결 방법

  1. CrewMemberRepository에 쿼리 메서드 추가

  // userId로 활성 크루 조회 (크루 정보 포함, 통계 업데이트용)
  @Query("SELECT cm FROM CrewMemberEntity cm " +
         "JOIN FETCH cm.crew " +
         "WHERE cm.user.id = :userId AND cm.isActive = true " +
         "ORDER BY cm.joinedAt DESC")
  List<CrewMemberEntity> findByUserIdWithCrew(@Param("userId") Long userId);

  2. RunningServiceImpl에 크루 통계 업데이트 로직 추가

  private void updateCrewStatisticsIfMember(Long userId, Double distanceKm, Integer durationSeconds) {
      try {
          // 사용자가 속한 활성 크루 조회
          List<CrewMemberEntity> memberships = crewMemberRepository.findByUserIdWithCrew(userId);

          if (memberships.isEmpty()) {
              return; // 크루 미가입 사용자는 스킵
          }

          String month = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
                  .format(DateTimeFormatter.ofPattern("yyyyMM"));

          for (CrewMemberEntity membership : memberships) {
              if (membership.getIsActive() && membership.getCrew().getIsActive()) {
                  crewStatisticsService.updateStatisticsAfterRun(
                          membership.getCrew().getId(),
                          userId,
                          month,
                          distanceKm,
                          durationSeconds.longValue()
                  );
              }
          }
      } catch (Exception e) {
          // 크루 통계 업데이트 실패 시에도 러닝 완료는 성공 처리
          log.error("크루 통계 업데이트 중 오류 발생: userId={}, error={}", userId, e.getMessage(), e);
      }
  }

  3. completeRunning() 메서드에서 호출

  user.updateRunningStats(distanceKm);
  userRepository.save(user);

  RunningRecord savedRecord = runningRecordRepository.save(record);
  runningRecordRepository.flush();

  // ✅ 크루 통계 업데이트 추가
  updateCrewStatisticsIfMember(user.getId(), distanceKm.doubleValue(), request.getDurationSeconds());

  var awardResult = emblemService.scanAndAward(user.getId(), "DISTANCE");

  ---
  변경 파일

  - CrewMemberRepository.java: userId 기반 크루 조회 메서드 추가
  - RunningServiceImpl.java: 크루 통계 업데이트 로직 통합

  ---
  테스트 시나리오

  ✅ 크루 미가입 사용자

  - 러닝 완료 → 개인 통계만 업데이트 → 정상 작동

  ✅ 크루 1개 가입 사용자

  - 러닝 완료 → 개인 통계 + 크루 통계 업데이트 → 정상 작동

  ✅ 크루 여러 개 가입 사용자

  - 러닝 완료 → 개인 통계 + 모든 크루 통계 업데이트 → 정상 작동

  ✅ 비활성 크루

  - 통계 업데이트 스킵 → 정상 작동

  ✅ 크루 통계 API 조회

  - 월간 거리, 러닝 횟수, 평균 페이스, MVP 정상 표시

  ✅ 크루 랭킹 API 조회

  - 거리 기준 랭킹 정상 반영

  ---
  안전 장치

  1. 크루 미가입자 체크: memberships.isEmpty() → 바로 리턴
  2. 비활성 크루 필터링: isActive && crew.getIsActive() 체크
  3. 예외 격리: try-catch로 크루 통계 실패 시에도 러닝 완료는 성공 처리
  4. 로깅: 성공/실패 모두 로그 기록

  ---
  결과

  이제 러닝 완료 시:
  1. ✅ 개인 통계 업데이트 (User.totalDistance, totalRunningCount)
  2. ✅ 크루 월간 통계 업데이트 (CrewStatistics.totalDistance, runCount, avgPace)
  3. ✅ 크루 MVP 자동 갱신 (월간 최고 거리 러너)
  4. ✅ 크루 랭킹 실시간 업데이트 (Redis ZSet)
  5. ✅ 엠블럼 자동 지급

