### PR TITLE
[Feat] Fix/critical concurrency and security issues

### DIFF
--- a/src/main/java/com/waytoearth/entity/crew/CrewStatisticsEntity.java
+++ b/src/main/java/com/waytoearth/entity/crew/CrewStatisticsEntity.java
@@ -98,11 +98,16 @@ public class CrewStatisticsEntity extends BaseTimeEntity {
         if (this.avgPaceSeconds == null) {
             this.avgPaceSeconds = memberPaceSeconds;
         } else {
-            // 거리 기반 가중평균으로 계산
-            BigDecimal totalWeightedPace = this.avgPaceSeconds.multiply(this.totalDistance.subtract(memberDistance));
-            BigDecimal newWeightedPace = memberPaceSeconds.multiply(memberDistance);
-            this.avgPaceSeconds = totalWeightedPace.add(newWeightedPace)
-                    .divide(this.totalDistance, 2, BigDecimal.ROUND_HALF_UP);
+            // division by zero 방지
+            if (this.totalDistance.compareTo(BigDecimal.ZERO) <= 0) {
+                this.avgPaceSeconds = memberPaceSeconds;
+            } else {
+                // 거리 기반 가중평균으로 계산
+                BigDecimal totalWeightedPace = this.avgPaceSeconds.multiply(this.totalDistance.subtract(memberDistance));
+                BigDecimal newWeightedPace = memberPaceSeconds.multiply(memberDistance);
+                this.avgPaceSeconds = totalWeightedPace.add(newWeightedPace)
+                        .divide(this.totalDistance, 2, BigDecimal.ROUND_HALF_UP);
+            }
         }
 
         // 새로운 활성 멤버인 경우 카운트 증가

--- a/src/main/java/com/waytoearth/repository/crew/CrewStatisticsRepositoryCustom.java
+++ b/src/main/java/com/waytoearth/repository/crew/CrewStatisticsRepositoryCustom.java
@@ -62,4 +62,9 @@ public interface CrewStatisticsRepositoryCustom {
      */
     CrewMemberRankingDto findMvpInCrew(Long crewId, String month);
 
+    /**
+     * 특정 사용자의 크루 내 월간 총 거리 조회 (N+1 방지)
+     */
+    java.math.BigDecimal findUserMonthlyDistanceInCrew(Long crewId, Long userId, String month);
+
 }

--- a/src/main/java/com/waytoearth/repository/crew/CrewStatisticsRepositoryImpl.java
+++ b/src/main/java/com/waytoearth/repository/crew/CrewStatisticsRepositoryImpl.java
@@ -253,6 +253,23 @@ public class CrewStatisticsRepositoryImpl implements CrewStatisticsRepositoryCus
                 .fetchOne();
     }
 
+    @Override
+    public BigDecimal findUserMonthlyDistanceInCrew(Long crewId, Long userId, String month) {
+        BigDecimal result = queryFactory
+                .select(runningRecord.distance.sum().coalesce(BigDecimal.ZERO))
+                .from(runningRecord)
+                .join(crewMemberEntity).on(crewMemberEntity.user.id.eq(runningRecord.user.id))
+                .where(crewMemberEntity.crew.id.eq(crewId)
+                        .and(crewMemberEntity.user.id.eq(userId))
+                        .and(crewMemberEntity.isActive.isTrue())
+                        .and(runningRecord.isCompleted.isTrue())
+                        .and(runningRecord.startedAt.year().eq(Integer.parseInt(month.substring(0, 4))))
+                        .and(runningRecord.startedAt.month().eq(Integer.parseInt(month.substring(4, 6)))))
+                .fetchOne();
+
+        return result != null ? result : BigDecimal.ZERO;
+    }
+
     private String calculatePreviousMonth(String month) {
         int year = Integer.parseInt(month.substring(0, 4));
         int monthNum = Integer.parseInt(month.substring(4, 6));

--- a/src/main/java/com/waytoearth/repository/running/RunningRecordRepository.java
+++ b/src/main/java/com/waytoearth/repository/running/RunningRecordRepository.java
@@ -7,10 +7,13 @@ import com.waytoearth.repository.statistics.StatisticsRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.EntityGraph;
+
+import jakarta.persistence.LockModeType;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -25,6 +28,11 @@ public interface RunningRecordRepository extends JpaRepository<RunningRecord, Lo
 
     // ===== 단건 조회 =====
     Optional<RunningRecord> findBySessionId(String sessionId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM RunningRecord r WHERE r.sessionId = :sessionId")
+    Optional<RunningRecord> findBySessionIdWithLock(@Param("sessionId") String sessionId);
+
     Optional<RunningRecord> findByIdAndUser(Long id, User user);
 
     // 진행 중인 세션(사용자당 0~1개가 정상)

--- a/src/main/java/com/waytoearth/repository/user/UserRepository.java
+++ b/src/main/java/com/waytoearth/repository/user/UserRepository.java
@@ -2,8 +2,12 @@ package com.waytoearth.repository.user;
 
 import com.waytoearth.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoId(Long kakaoId);
 
     boolean existsByNickname(String nickname);
+
+    @Modifying
+    @Query("UPDATE User u SET u.totalDistance = u.totalDistance + :distance, u.totalRunningCount = u.totalRunningCount + 1 WHERE u.id = :userId")
+    int updateRunningStatsAtomic(@Param("userId") Long userId, @Param("distance") BigDecimal distance);
 }

--- a/src/main/java/com/waytoearth/service/auth/JwtTokenProvider.java
+++ b/src/main/java/com/waytoearth/service/auth/JwtTokenProvider.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 @Component
@@ -23,7 +24,14 @@ public class JwtTokenProvider {
             @Value("${jwt.secret}") String secret,
             @Value("${jwt.expiration:86400000}") long expiration) {
         log.info("JWT configuration initialized with expiration: {}ms", expiration);
-        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+
+        // 비밀키 최소 길이 검증 (HMAC-SHA256: 256비트 = 32바이트)
+        byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
+        if (keyBytes.length < 32) {
+            throw new IllegalArgumentException("JWT secret key must be at least 32 bytes (256 bits) for HS256");
+        }
+
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
         this.jwtExpirationMs = expiration;
     }
 

--- a/src/main/java/com/waytoearth/service/crew/CrewStatisticsServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/crew/CrewStatisticsServiceImpl.java
@@ -92,8 +92,15 @@ public class CrewStatisticsServiceImpl implements CrewStatisticsService {
         // 통계 업데이트
         // distance를 BigDecimal로 변환
         BigDecimal distanceBd = BigDecimal.valueOf(distance);
-        // duration에서 pace 계산 (초)
-        BigDecimal paceSeconds = BigDecimal.valueOf(duration).divide(distanceBd, 2, BigDecimal.ROUND_HALF_UP);
+
+        // duration에서 pace 계산 (초) - division by zero 방지
+        BigDecimal paceSeconds;
+        if (distanceBd.compareTo(BigDecimal.ZERO) <= 0) {
+            log.warn("거리가 0 이하입니다. 통계 업데이트를 건너뜁니다. crewId: {}, userId: {}, distance: {}",
+                    crewId, userId, distance);
+            return;
+        }
+        paceSeconds = BigDecimal.valueOf(duration).divide(distanceBd, 2, BigDecimal.ROUND_HALF_UP);
 
         stats.updateWithMemberRun(distanceBd, paceSeconds, false);
 
@@ -249,12 +256,18 @@ public class CrewStatisticsServiceImpl implements CrewStatisticsService {
             } else {
                 // 거리 기반 가중평균 계산
                 BigDecimal currentTotalDistance = stats.getTotalDistance();
-                BigDecimal previousDistance = currentTotalDistance.subtract(memberDistance);
 
-                BigDecimal totalWeightedPace = stats.getAvgPaceSeconds().multiply(previousDistance);
-                BigDecimal newWeightedPace = memberPaceSeconds.multiply(memberDistance);
-                newAvgPace = totalWeightedPace.add(newWeightedPace)
-                        .divide(currentTotalDistance, 2, BigDecimal.ROUND_HALF_UP);
+                // division by zero 방지
+                if (currentTotalDistance.compareTo(BigDecimal.ZERO) <= 0) {
+                    newAvgPace = memberPaceSeconds;
+                } else {
+                    BigDecimal previousDistance = currentTotalDistance.subtract(memberDistance);
+
+                    BigDecimal totalWeightedPace = stats.getAvgPaceSeconds().multiply(previousDistance);
+                    BigDecimal newWeightedPace = memberPaceSeconds.multiply(memberDistance);
+                    newAvgPace = totalWeightedPace.add(newWeightedPace)
+                            .divide(currentTotalDistance, 2, BigDecimal.ROUND_HALF_UP);
+                }
             }
 
             // 원자적 평균 페이스 업데이트

--- a/src/main/java/com/waytoearth/service/crew/CrewStatisticsServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/crew/CrewStatisticsServiceImpl.java
@@ -335,17 +335,10 @@ public class CrewStatisticsServiceImpl implements CrewStatisticsService {
     }
 
     /**
-     * 사용자의 월간 누적 거리 조회
+     * 사용자의 월간 누적 거리 조회 (N+1 쿼리 최적화)
      */
     private BigDecimal getUserMonthlyTotalDistance(Long crewId, Long userId, String month) {
-        // 해당 월의 사용자 러닝 기록 합계를 직접 계산
-        // CrewMemberRankingDto에서 이미 같은 정보를 제공하므로 간소화
-        List<CrewMemberRankingDto> ranking = statisticsRepository.findMemberRankingInCrew(crewId, month, 100);
-        return ranking.stream()
-                .filter(member -> member.getUserId().equals(userId))
-                .findFirst()
-                .map(CrewMemberRankingDto::getTotalDistance)
-                .orElse(BigDecimal.ZERO);
+        return statisticsRepository.findUserMonthlyDistanceInCrew(crewId, userId, month);
     }
 
     /**

--- a/src/main/java/com/waytoearth/service/crew/CrewStatisticsUpdater.java
+++ b/src/main/java/com/waytoearth/service/crew/CrewStatisticsUpdater.java
@@ -1,0 +1,77 @@
+package com.waytoearth.service.crew;
+
+import com.waytoearth.entity.crew.CrewMemberEntity;
+import com.waytoearth.repository.crew.CrewMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * 크루 통계 업데이트 전용 컴포넌트 (재시도 로직 포함)
+ * @Retryable이 프록시 기반으로 작동하기 위해 별도 컴포넌트로 분리
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CrewStatisticsUpdater {
+
+    private final CrewMemberRepository crewMemberRepository;
+    private final CrewStatisticsService crewStatisticsService;
+
+    /**
+     * 사용자가 크루 멤버인 경우 크루 통계 업데이트 (재시도 로직 포함)
+     * - 크루 월간 통계 (거리, 횟수, 페이스) 업데이트
+     * - 크루 MVP 갱신
+     * - Redis 랭킹 실시간 업데이트
+     */
+    @Retryable(
+        value = {Exception.class},
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 500, multiplier = 2)
+    )
+    public void updateCrewStatisticsIfMember(Long userId, Double distanceKm, Integer durationSeconds) {
+        // 사용자가 속한 활성 크루 조회
+        List<CrewMemberEntity> memberships = crewMemberRepository.findByUserIdWithCrew(userId);
+
+        if (memberships.isEmpty()) {
+            return; // 크루 미가입 사용자는 스킵
+        }
+
+        String month = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .format(DateTimeFormatter.ofPattern("yyyyMM"));
+
+        for (CrewMemberEntity membership : memberships) {
+            if (membership.getIsActive() && membership.getCrew().getIsActive()) {
+                crewStatisticsService.updateStatisticsAfterRun(
+                        membership.getCrew().getId(),
+                        userId,
+                        month,
+                        distanceKm,
+                        durationSeconds.longValue()
+                );
+
+                log.info("크루 통계 업데이트 완료: crewId={}, userId={}, distance={}km",
+                        membership.getCrew().getId(), userId, distanceKm);
+            }
+        }
+    }
+
+    /**
+     * 크루 통계 업데이트 재시도 실패 시 복구 메서드
+     */
+    @Recover
+    public void recoverCrewStatisticsUpdate(Exception e, Long userId, Double distanceKm, Integer durationSeconds) {
+        // 최종 실패 시에도 러닝 완료는 성공 처리
+        log.error("크루 통계 업데이트 최종 실패 (3회 재시도 후): userId={}, distance={}km, error={}",
+                userId, distanceKm, e.getMessage(), e);
+        // TODO: 실패한 업데이트를 별도 큐에 저장하여 배치로 재처리 고려
+    }
+}

--- a/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
@@ -17,17 +17,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Recover;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -40,8 +35,7 @@ public class RunningServiceImpl implements RunningService {
     private final RunningRouteRepository runningRouteRepository;
     private final UserRepository userRepository;
     private final EmblemService emblemService;  // 엠블럼 자동 지급
-    private final com.waytoearth.repository.crew.CrewMemberRepository crewMemberRepository;  // 크루 통계 연동
-    private final com.waytoearth.service.crew.CrewStatisticsService crewStatisticsService;  // 크루 통계 업데이트
+    private final com.waytoearth.service.crew.CrewStatisticsUpdater crewStatisticsUpdater;  // 크루 통계 업데이트 (재시도 포함)
 
     @Override
     public RunningStartResponse startRunning(AuthenticatedUser authUser, RunningStartRequest request) {
@@ -149,8 +143,18 @@ public class RunningServiceImpl implements RunningService {
 
         User user = record.getUser();
 
-        // 크루 통계 업데이트 (크루 랭킹, MVP, Redis 캐시 자동 갱신)
-        updateCrewStatisticsIfMember(user.getId(), distanceKm.doubleValue(), request.getDurationSeconds());
+        // 크루 통계 업데이트 (크루 랭킹, MVP, Redis 캐시 자동 갱신) - 재시도 로직 포함
+        try {
+            crewStatisticsUpdater.updateCrewStatisticsIfMember(
+                    user.getId(),
+                    distanceKm.doubleValue(),
+                    request.getDurationSeconds()
+            );
+        } catch (Exception e) {
+            // 재시도 후에도 실패 시 로깅만 하고 러닝 완료는 유지
+            log.error("크루 통계 업데이트 실패 (재시도 완료됨): userId={}, error={}",
+                    user.getId(), e.getMessage());
+        }
 
         var awardResult = emblemService.scanAndAward(user.getId(), "DISTANCE");
 
@@ -247,54 +251,5 @@ public class RunningServiceImpl implements RunningService {
         );
     }
 
-    /**
-     * 사용자가 크루 멤버인 경우 크루 통계 업데이트 (재시도 로직 포함)
-     * - 크루 월간 통계 (거리, 횟수, 페이스) 업데이트
-     * - 크루 MVP 갱신
-     * - Redis 랭킹 실시간 업데이트
-     */
-    @Retryable(
-        value = {Exception.class},
-        maxAttempts = 3,
-        backoff = @Backoff(delay = 500, multiplier = 2)
-    )
-    private void updateCrewStatisticsIfMember(Long userId, Double distanceKm, Integer durationSeconds) {
-        // 사용자가 속한 활성 크루 조회
-        List<com.waytoearth.entity.crew.CrewMemberEntity> memberships =
-                crewMemberRepository.findByUserIdWithCrew(userId);
-
-        if (memberships.isEmpty()) {
-            return; // 크루 미가입 사용자는 스킵
-        }
-
-        String month = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
-                .format(DateTimeFormatter.ofPattern("yyyyMM"));
-
-        for (com.waytoearth.entity.crew.CrewMemberEntity membership : memberships) {
-            if (membership.getIsActive() && membership.getCrew().getIsActive()) {
-                crewStatisticsService.updateStatisticsAfterRun(
-                        membership.getCrew().getId(),
-                        userId,
-                        month,
-                        distanceKm,
-                        durationSeconds.longValue()
-                );
-
-                log.info("크루 통계 업데이트 완료: crewId={}, userId={}, distance={}km",
-                        membership.getCrew().getId(), userId, distanceKm);
-            }
-        }
-    }
-
-    /**
-     * 크루 통계 업데이트 재시도 실패 시 복구 메서드
-     */
-    @Recover
-    private void recoverCrewStatisticsUpdate(Exception e, Long userId, Double distanceKm, Integer durationSeconds) {
-        // 최종 실패 시에도 러닝 완료는 성공 처리
-        log.error("크루 통계 업데이트 최종 실패 (3회 재시도 후): userId={}, distance={}km, error={}",
-                userId, distanceKm, e.getMessage(), e);
-        // TODO: 실패한 업데이트를 별도 큐에 저장하여 배치로 재처리 고려
-    }
 }
 

--- a/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
@@ -138,12 +138,13 @@ public class RunningServiceImpl implements RunningService {
             );
         }
 
-        User user = record.getUser();
-        user.updateRunningStats(distanceKm);
-        userRepository.save(user);
-
         RunningRecord savedRecord = runningRecordRepository.save(record);
         runningRecordRepository.flush();
+
+        // 동시성 안전한 원자적 통계 업데이트
+        userRepository.updateRunningStatsAtomic(authUser.getUserId(), distanceKm);
+
+        User user = record.getUser();
 
         // 크루 통계 업데이트 (크루 랭킹, MVP, Redis 캐시 자동 갱신)
         updateCrewStatisticsIfMember(user.getId(), distanceKm.doubleValue(), request.getDurationSeconds());

--- a/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/running/RunningServiceImpl.java
@@ -85,7 +85,7 @@ public class RunningServiceImpl implements RunningService {
 
     @Override
     public void pauseRunning(AuthenticatedUser authUser, RunningPauseResumeRequest request) {
-        RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
+        RunningRecord record = runningRecordRepository.findBySessionIdWithLock(request.getSessionId())
                 .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
 
         if (!record.getUser().getId().equals(authUser.getUserId())) {
@@ -102,7 +102,7 @@ public class RunningServiceImpl implements RunningService {
             throw new IllegalArgumentException("sessionId는 필수입니다.");
         }
 
-        RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
+        RunningRecord record = runningRecordRepository.findBySessionIdWithLock(request.getSessionId())
                 .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
 
         if (!record.getUser().getId().equals(authUser.getUserId())) {
@@ -115,7 +115,7 @@ public class RunningServiceImpl implements RunningService {
 
     @Override
     public RunningCompleteResponse completeRunning(AuthenticatedUser authUser, RunningCompleteRequest request) {
-        RunningRecord record = runningRecordRepository.findBySessionId(request.getSessionId())
+        RunningRecord record = runningRecordRepository.findBySessionIdWithLock(request.getSessionId())
                 .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
 
         if (!record.getUser().getId().equals(authUser.getUserId())) {


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #83

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

##  작업 내용

###  버그 수정

#### 1. User 통계 동시성 버그 해결 
**문제**: 동시 러닝 완료 시 통계 손실 (Lost Update)

**변경 사항**:
- `UserRepository.java:20-22` - 원자적 UPDATE 쿼리 `updateRunningStatsAtomic()` 추가
- `RunningServiceImpl.java:145` - 비원자적 메서드 대신 원자적 쿼리 사용

**결과**: DB 레벨에서 `total_distance = total_distance + ?` 방식으로 동시성 안전 보장

---

#### 2. JWT 비밀키 보안 강화 
**문제**:
- 플랫폼 종속 인코딩 (`getBytes()`)
- 약한 키 허용 (최소 길이 검증 없음)

**변경 사항**:
- `JwtTokenProvider.java:12` - `StandardCharsets.UTF_8` import
- `JwtTokenProvider.java:29-32` - 최소 32바이트 검증 로직 추가
- `JwtTokenProvider.java:29` - `getBytes(StandardCharsets.UTF_8)` 명시적 인코딩

**결과**:
- 크로스 플랫폼 일관성 보장
- HMAC-SHA256 권장 최소 길이 강제

---

#### 3. RunningRecord 상태 충돌 방지 
**문제**: pause/resume/complete 동시 호출 시 상태 꼬임

**변경 사항**:
- `RunningRecordRepository.java:10,16` - Lock 관련 import
- `RunningRecordRepository.java:32-34` - `findBySessionIdWithLock()` 추가
- `RunningServiceImpl.java:88,105,118` - 상태 변경 메서드에 Lock 적용

**결과**: DB 행 레벨 락으로 순차 처리 보장

---

###  성능 및 안정성 개선 

#### 4. N+1 쿼리 최적화 
**문제**: 1명 데이터 필요한데 100명 조회

**변경 사항**:
- `CrewStatisticsRepositoryCustom.java:65-68` - `findUserMonthlyDistanceInCrew()` 인터페이스
- `CrewStatisticsRepositoryImpl.java:256-271` - 단일 사용자 타겟 쿼리 구현
- `CrewStatisticsServiceImpl.java:340-342` - 최적화된 쿼리 사용

**성능 개선**: 100명 크루 기준 데이터 조회량 **100배 감소**

---

#### 5. Division by Zero 방어 코드 추가 
**문제**: 거리 0인 러닝 완료 시 ArithmeticException

**변경 사항**:
- `CrewStatisticsServiceImpl.java:98-103` - distance 0 체크 및 early return
- `CrewStatisticsServiceImpl.java:260-270` - currentTotalDistance 0 체크
- `CrewStatisticsEntity.java:101-110` - totalDistance 0 체크

**결과**: 3곳 모든 나눗셈 연산에 안전장치 추가

---

#### 6. 크루 통계 업데이트 재시도 로직 
**문제**: 일시적 장애로 통계 영구 손실

**변경 사항**:
- `CrewStatisticsUpdater.java` - 재시도 로직 전용 컴포넌트 신규 생성
  - `@Retryable` (3회, 500ms → 1s → 2s 지수 백오프)
  - `@Recover` 최종 실패 처리 메서드
- `RunningServiceImpl.java:40` - `CrewStatisticsUpdater` 의존성 주입
- `RunningServiceImpl.java:149-159` - 재시도 로직을 포함한 통계 업데이트 호출

**기술적 개선**:
- `@Retryable`은 Spring AOP 프록시 기반이라 private 메서드에서 작동 안 함
- 별도 `@Component`로 분리하여 프록시 정상 작동
- 순환 참조 방지 및 단일 책임 원칙 준수

**결과**: 일시적 장애 자동 복구, 최종 실패 시에도 러닝 완료는 유지

---

#### 7. Redis 랭킹 복구 기능 완성 
**문제**: TODO만 있고 구현 안 됨

**변경 사항**:
- `CrewRankingServiceImpl.java:110-125` - `rebuildRankingFromDB()` 완전 구현
- `CrewRankingServiceImpl.java:127-158` - 크루 랭킹 재구축
- `CrewRankingServiceImpl.java:160-176` - 전체 크루 멤버 랭킹 재구축
- `CrewRankingServiceImpl.java:178-209` - 특정 크루 멤버 랭킹 재구축

**결과**: Redis 장애/데이터 손실 시 DB에서 복구 가능

---

##  영향 범위
- **User 통계**: 동시성 안전 보장
- **JWT 인증**: 보안 강화
- **러닝 세션**: 상태 일관성 보장
- **크루 통계**: 성능 개선 + 안정성 강화
- **Redis 랭킹**: 복구 기능 완성

##  테스트 체크리스트
- [ ] 동시에 여러 러닝 완료 시 User 통계 정확성 확인
- [ ] JWT 토큰 생성 시 32바이트 미만 키로 실패하는지 확인
- [ ] 같은 세션에 pause/resume 동시 호출 시 정상 처리 확인
- [ ] 크루 통계 조회 쿼리 성능 측정 (EXPLAIN ANALYZE)
- [ ] 거리 0인 러닝 완료 시 에러 없이 처리되는지 확인
- [ ] 크루 통계 업데이트 실패 시 재시도 로그 확인 (3회 재시도 동작 검증)
- [ ] Redis 데이터 삭제 후 `rebuildRankingFromDB()` 호출로 복구 확인
- [ ] 애플리케이션 정상 기동 확인 (빈 순환 참조 해결)

## 💬 리뷰 요구사항 (선택)
1. **동시성 처리**: 원자적 쿼리 vs 비관적 락 선택이 적절한지
2. **JWT 보안**: 32바이트 최소 길이가 충분한지 (더 강화 필요 여부)
3. **재시도 정책**: `CrewStatisticsUpdater` 컴포넌트 분리가 적절한지, 3회/지수백오프가 적절한지
4. **Redis 복구**: limit=1000으로 충분한지 (크루/멤버 규모 고려)
5. **아키텍처**: 통계 업데이트 로직을 별도 컴포넌트로 분리한 설계가 향후 확장성에 도움이 되는지

## 관련 파일
- `src/main/java/com/waytoearth/repository/user/UserRepository.java`
- `src/main/java/com/waytoearth/service/auth/JwtTokenProvider.java`
- `src/main/java/com/waytoearth/repository/running/RunningRecordRepository.java`
- `src/main/java/com/waytoearth/service/running/RunningServiceImpl.java`


- `src/main/java/com/waytoearth/repository/crew/CrewStatisticsRepositoryCustom.java`
- `src/main/java/com/waytoearth/repository/crew/CrewStatisticsRepositoryImpl.java`
- `src/main/java/com/waytoearth/service/crew/CrewStatisticsServiceImpl.java`


- `src/main/java/com/waytoearth/entity/crew/CrewStatisticsEntity.java`
- `src/main/java/com/waytoearth/service/ranking/CrewRankingServiceImpl.java`
- `src/main/java/com/waytoearth/service/crew/CrewStatisticsUpdater.java` 

---

##  추가 수정 사항

### 빈 순환 참조 문제 해결
**문제**:
- `@Retryable`을 private 메서드에 적용 시 Spring AOP 프록시 미작동
- 애플리케이션 기동 실패 (`CrewService` 빈 생성 불가)

**해결**:
1. **`CrewStatisticsUpdater.java` 신규 생성**
   - 크루 통계 업데이트 로직을 별도 `@Component`로 분리
   - `@Retryable` 프록시가 정상 작동하도록 public 메서드로 구현
   - 단일 책임 원칙(SRP) 준수

2. **`RunningServiceImpl.java` 리팩토링**
   - `CrewStatisticsUpdater` 의존성 주입
   - private 메서드 제거 및 외부 컴포넌트 호출로 변경
   - import 정리 (불필요한 DateTimeFormatter, List 제거)
