### PR TITLE
feat: 푸시 알림 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,11 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      - name: Create Firebase Service Account JSON
+        run: |
+          mkdir -p src/main/resources/firebase
+          echo '${{ secrets.FCM_CONFIG_JSON }}' > src/main/resources/firebase/firebase-service-account.json
+
       - name: Build with Gradle (Skip Tests)
         run: ./gradlew build -x test
 
@@ -107,6 +112,8 @@ jobs:
               -e JWT_EXPIRATION="${{ vars.JWT_EXPIRATION }}" \
               -e REDIS_HOST="${{ secrets.REDIS_HOST }}" \
               -e REDIS_PORT="${{ vars.REDIS_PORT }}" \
+              -e FCM_CONFIG_PATH="${{ vars.FCM_CONFIG_PATH }}" \
+              -e FCM_ENABLED="${{ vars.FCM_ENABLED }}" \
               "$IMAGE_NAME"
 
             echo "🧹 안 쓰는 이미지 정리"

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ out/
 /src/main/generated/
 .claude/
 /WayToEarth-프로젝트-전체-분석.md
+/src/main/resources/firebase/waytoearth-firebase-adminsdk.json

--- a/src/main/java/com/waytoearth/config/FcmConfig.java
+++ b/src/main/java/com/waytoearth/config/FcmConfig.java
@@ -1,0 +1,40 @@
+package com.waytoearth.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Slf4j
+@Configuration
+public class FcmConfig {
+
+    @Value("${fcm.firebase.config-path}")
+    private String firebaseConfigPath;
+
+    @PostConstruct
+    public void initialize() {
+        try {
+            FileInputStream serviceAccount = new FileInputStream(firebaseConfigPath);
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                log.info("✅ Firebase Admin SDK 초기화 성공");
+            }
+        } catch (IOException e) {
+            log.error("❌ Firebase Admin SDK 초기화 실패: {}", e.getMessage());
+            throw new RuntimeException("Firebase 초기화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/waytoearth/controller/v1/notification/NotificationController.java
+++ b/src/main/java/com/waytoearth/controller/v1/notification/NotificationController.java
@@ -1,0 +1,122 @@
+package com.waytoearth.controller.v1.notification;
+
+import com.waytoearth.dto.request.notification.FcmTokenRequest;
+import com.waytoearth.dto.request.notification.NotificationSettingUpdateRequest;
+import com.waytoearth.dto.response.common.ApiResponse;
+import com.waytoearth.dto.response.notification.NotificationSettingResponse;
+import com.waytoearth.security.AuthUser;
+import com.waytoearth.security.AuthenticatedUser;
+import com.waytoearth.service.notification.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "알림 API", description = "FCM 토큰 관리 및 알림 설정 API")
+@RestController
+@RequestMapping("/v1/notifications")
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(
+            summary = "FCM 토큰 등록",
+            description = "푸시 알림을 위한 FCM 토큰 등록/갱신",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @PostMapping("/fcm-token")
+    public ResponseEntity<ApiResponse<String>> registerFcmToken(
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser user,
+            @Parameter(description = "FCM 토큰 등록 요청", required = true)
+            @RequestBody @Valid FcmTokenRequest request) {
+
+        notificationService.registerFcmToken(user.getUserId(), request);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                null,
+                "FCM 토큰이 등록되었습니다."
+        ));
+    }
+
+    @Operation(
+            summary = "FCM 토큰 비활성화",
+            description = "특정 디바이스의 FCM 토큰 비활성화 (로그아웃 시)",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @DeleteMapping("/fcm-token/{deviceId}")
+    public ResponseEntity<ApiResponse<String>> deactivateFcmToken(
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser user,
+            @Parameter(description = "디바이스 ID", required = true)
+            @PathVariable String deviceId) {
+
+        notificationService.deactivateFcmToken(user.getUserId(), deviceId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                null,
+                "FCM 토큰이 비활성화되었습니다."
+        ));
+    }
+
+    @Operation(
+            summary = "모든 FCM 토큰 비활성화",
+            description = "사용자의 모든 디바이스 FCM 토큰 비활성화",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @DeleteMapping("/fcm-token")
+    public ResponseEntity<ApiResponse<String>> deactivateAllTokens(
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser user) {
+
+        notificationService.deactivateAllUserTokens(user.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success(
+                null,
+                "모든 FCM 토큰이 비활성화되었습니다."
+        ));
+    }
+
+    @Operation(
+            summary = "알림 설정 조회",
+            description = "사용자의 알림 설정 조회",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/settings")
+    public ResponseEntity<ApiResponse<NotificationSettingResponse>> getNotificationSettings(
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser user) {
+
+        NotificationSettingResponse response = notificationService.getNotificationSettings(user.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success(
+                response,
+                "알림 설정 조회 성공"
+        ));
+    }
+
+    @Operation(
+            summary = "알림 설정 업데이트",
+            description = "사용자의 알림 설정 업데이트",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @PatchMapping("/settings")
+    public ResponseEntity<ApiResponse<NotificationSettingResponse>> updateNotificationSettings(
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser user,
+            @Parameter(description = "알림 설정 업데이트 요청", required = true)
+            @RequestBody @Valid NotificationSettingUpdateRequest request) {
+
+        NotificationSettingResponse response = notificationService.updateNotificationSettings(
+                user.getUserId(),
+                request
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                response,
+                "알림 설정이 업데이트되었습니다."
+        ));
+    }
+}

--- a/src/main/java/com/waytoearth/dto/request/notification/FcmTokenRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/notification/FcmTokenRequest.java
@@ -1,0 +1,28 @@
+package com.waytoearth.dto.request.notification;
+
+import com.waytoearth.entity.notification.FcmToken.DeviceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "FCM 토큰 등록 요청")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FcmTokenRequest {
+
+    @Schema(description = "FCM 토큰", example = "dXGfz1234...", required = true)
+    @NotBlank(message = "FCM 토큰은 필수입니다")
+    private String fcmToken;
+
+    @Schema(description = "디바이스 ID (고유 식별자)", example = "device-uuid-1234", required = true)
+    @NotBlank(message = "디바이스 ID는 필수입니다")
+    private String deviceId;
+
+    @Schema(description = "디바이스 타입", example = "ANDROID", required = true)
+    @NotNull(message = "디바이스 타입은 필수입니다")
+    private DeviceType deviceType;
+}

--- a/src/main/java/com/waytoearth/dto/request/notification/NotificationSettingUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/notification/NotificationSettingUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.waytoearth.dto.request.notification;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "알림 설정 업데이트 요청")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationSettingUpdateRequest {
+
+    @Schema(description = "정기 러닝 알림", example = "true")
+    private Boolean scheduledRunningReminder;
+
+    @Schema(description = "크루 알림", example = "true")
+    private Boolean crewNotification;
+
+    @Schema(description = "피드 알림", example = "true")
+    private Boolean feedNotification;
+
+    @Schema(description = "엠블럼 알림", example = "true")
+    private Boolean emblemNotification;
+
+    @Schema(description = "전체 알림", example = "true")
+    private Boolean allNotificationsEnabled;
+}

--- a/src/main/java/com/waytoearth/dto/response/notification/NotificationSettingResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/notification/NotificationSettingResponse.java
@@ -1,0 +1,30 @@
+package com.waytoearth.dto.response.notification;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "알림 설정 응답")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationSettingResponse {
+
+    @Schema(description = "정기 러닝 알림", example = "true")
+    private Boolean scheduledRunningReminder;
+
+    @Schema(description = "크루 알림", example = "true")
+    private Boolean crewNotification;
+
+    @Schema(description = "피드 알림", example = "true")
+    private Boolean feedNotification;
+
+    @Schema(description = "엠블럼 알림", example = "true")
+    private Boolean emblemNotification;
+
+    @Schema(description = "전체 알림", example = "true")
+    private Boolean allNotificationsEnabled;
+}

--- a/src/main/java/com/waytoearth/entity/notification/FcmToken.java
+++ b/src/main/java/com/waytoearth/entity/notification/FcmToken.java
@@ -1,0 +1,78 @@
+package com.waytoearth.entity.notification;
+
+import com.waytoearth.entity.common.BaseTimeEntity;
+import com.waytoearth.entity.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * FCM 디바이스 토큰 엔티티
+ * - 사용자 디바이스별 푸시 알림 토큰 관리
+ * - 한 사용자가 여러 디바이스 가능 (폰, 태블릿 등)
+ */
+@Entity
+@Table(
+        name = "fcm_tokens",
+        indexes = {
+                @Index(name = "idx_fcm_user", columnList = "user_id"),
+                @Index(name = "idx_fcm_token", columnList = "fcm_token"),
+                @Index(name = "idx_fcm_active", columnList = "is_active")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_fcm_user_device", columnNames = {"user_id", "device_id"})
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FcmToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 토큰 소유자 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /** FCM 디바이스 토큰 (Firebase가 발급) */
+    @Column(name = "fcm_token", nullable = false, length = 500)
+    private String fcmToken;
+
+    /** 디바이스 고유 ID (앱에서 생성) */
+    @Column(name = "device_id", nullable = false, length = 100)
+    private String deviceId;
+
+    /** 디바이스 타입 */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "device_type", length = 20)
+    private DeviceType deviceType;
+
+    /** 활성화 여부 (로그아웃 시 false) */
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private Boolean isActive = true;
+
+    public enum DeviceType {
+        IOS,
+        ANDROID
+    }
+
+    /**
+     * 토큰 업데이트 (같은 디바이스에서 토큰 갱신 시)
+     */
+    public void updateToken(String newToken) {
+        this.fcmToken = newToken;
+        this.isActive = true;
+    }
+
+    /**
+     * 비활성화 (로그아웃 시)
+     */
+    public void deactivate() {
+        this.isActive = false;
+    }
+}

--- a/src/main/java/com/waytoearth/entity/notification/NotificationSetting.java
+++ b/src/main/java/com/waytoearth/entity/notification/NotificationSetting.java
@@ -1,0 +1,87 @@
+package com.waytoearth.entity.notification;
+
+import com.waytoearth.entity.common.BaseTimeEntity;
+import com.waytoearth.entity.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 사용자별 알림 설정
+ * - 정기 알림, 크루 알림, 피드 알림 등 ON/OFF
+ */
+@Entity
+@Table(
+        name = "notification_settings",
+        indexes = {
+                @Index(name = "idx_noti_user", columnList = "user_id")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationSetting extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 설정 소유자 */
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    /** 정기 러닝 알림 (오전/저녁) */
+    @Column(name = "scheduled_running_reminder", nullable = false)
+    @Builder.Default
+    private Boolean scheduledRunningReminder = true;
+
+    /** 크루 관련 알림 (가입 승인, 채팅 등) */
+    @Column(name = "crew_notification", nullable = false)
+    @Builder.Default
+    private Boolean crewNotification = true;
+
+    /** 피드 관련 알림 (좋아요, 댓글 등) */
+    @Column(name = "feed_notification", nullable = false)
+    @Builder.Default
+    private Boolean feedNotification = true;
+
+    /** 엠블럼 획득 알림 */
+    @Column(name = "emblem_notification", nullable = false)
+    @Builder.Default
+    private Boolean emblemNotification = true;
+
+    /** 전체 알림 끄기 */
+    @Column(name = "all_notifications_enabled", nullable = false)
+    @Builder.Default
+    private Boolean allNotificationsEnabled = true;
+
+    /**
+     * 정기 알림 수신 가능 여부 확인
+     */
+    public boolean canReceiveScheduledReminder() {
+        return allNotificationsEnabled && scheduledRunningReminder;
+    }
+
+    /**
+     * 크루 알림 수신 가능 여부 확인
+     */
+    public boolean canReceiveCrewNotification() {
+        return allNotificationsEnabled && crewNotification;
+    }
+
+    /**
+     * 피드 알림 수신 가능 여부 확인
+     */
+    public boolean canReceiveFeedNotification() {
+        return allNotificationsEnabled && feedNotification;
+    }
+
+    /**
+     * 엠블럼 알림 수신 가능 여부 확인
+     */
+    public boolean canReceiveEmblemNotification() {
+        return allNotificationsEnabled && emblemNotification;
+    }
+}

--- a/src/main/java/com/waytoearth/repository/notification/FcmTokenRepository.java
+++ b/src/main/java/com/waytoearth/repository/notification/FcmTokenRepository.java
@@ -1,0 +1,51 @@
+package com.waytoearth.repository.notification;
+
+import com.waytoearth.entity.notification.FcmToken;
+import com.waytoearth.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    /** 사용자의 활성 토큰 조회 */
+    List<FcmToken> findByUserAndIsActiveTrue(User user);
+
+    /** 사용자 ID로 활성 토큰 조회 */
+    @Query("SELECT f FROM FcmToken f WHERE f.user.id = :userId AND f.isActive = true")
+    List<FcmToken> findActiveTokensByUserId(@Param("userId") Long userId);
+
+    /** 전체 활성 토큰 조회 (정기 알림용) */
+    @Query("SELECT f FROM FcmToken f WHERE f.isActive = true")
+    List<FcmToken> findAllActiveTokens();
+
+    /** 사용자 + 디바이스로 토큰 조회 */
+    Optional<FcmToken> findByUserAndDeviceId(User user, String deviceId);
+
+    /** FCM 토큰 문자열로 조회 */
+    Optional<FcmToken> findByFcmToken(String fcmToken);
+
+    /** 토큰 존재 여부 확인 */
+    boolean existsByUserAndDeviceId(User user, String deviceId);
+
+    /** 토큰 비활성화 */
+    @Modifying
+    @Query("UPDATE FcmToken f SET f.isActive = false WHERE f.fcmToken = :token")
+    int deactivateToken(@Param("token") String token);
+
+    /** 사용자의 모든 토큰 비활성화 */
+    @Modifying
+    @Query("UPDATE FcmToken f SET f.isActive = false WHERE f.user.id = :userId")
+    int deactivateAllUserTokens(@Param("userId") Long userId);
+
+    /** 특정 디바이스 토큰 비활성화 */
+    @Modifying
+    @Query("UPDATE FcmToken f SET f.isActive = false WHERE f.user.id = :userId AND f.deviceId = :deviceId")
+    int deactivateUserDeviceToken(@Param("userId") Long userId, @Param("deviceId") String deviceId);
+}

--- a/src/main/java/com/waytoearth/repository/notification/NotificationSettingRepository.java
+++ b/src/main/java/com/waytoearth/repository/notification/NotificationSettingRepository.java
@@ -1,0 +1,24 @@
+package com.waytoearth.repository.notification;
+
+import com.waytoearth.entity.notification.NotificationSetting;
+import com.waytoearth.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+
+    /** 사용자의 알림 설정 조회 */
+    Optional<NotificationSetting> findByUser(User user);
+
+    /** 사용자 ID로 알림 설정 조회 */
+    @Query("SELECT ns FROM NotificationSetting ns WHERE ns.user.id = :userId")
+    Optional<NotificationSetting> findByUserId(@Param("userId") Long userId);
+
+    /** 사용자에게 알림 설정이 있는지 확인 */
+    boolean existsByUser(User user);
+}

--- a/src/main/java/com/waytoearth/service/notification/FcmService.java
+++ b/src/main/java/com/waytoearth/service/notification/FcmService.java
@@ -1,0 +1,229 @@
+package com.waytoearth.service.notification;
+
+import com.google.firebase.messaging.*;
+import com.waytoearth.entity.notification.FcmToken;
+import com.waytoearth.entity.notification.NotificationSetting;
+import com.waytoearth.entity.user.User;
+import com.waytoearth.repository.notification.FcmTokenRepository;
+import com.waytoearth.repository.notification.NotificationSettingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    @Value("${fcm.notifications.enabled:true}")
+    private boolean notificationsEnabled;
+
+    /**
+     * 단일 사용자에게 푸시 알림 전송
+     */
+    public void sendNotificationToUser(Long userId, String title, String body) {
+        if (!notificationsEnabled) {
+            log.debug("FCM 알림이 비활성화되어 있습니다.");
+            return;
+        }
+
+        // 알림 설정 확인
+        NotificationSetting setting = notificationSettingRepository.findByUserId(userId)
+                .orElse(null);
+
+        if (setting == null || !setting.getAllNotificationsEnabled()) {
+            log.debug("사용자 {}는 알림을 비활성화했습니다.", userId);
+            return;
+        }
+
+        // 활성 토큰 조회
+        List<FcmToken> tokens = fcmTokenRepository.findActiveTokensByUserId(userId);
+        if (tokens.isEmpty()) {
+            log.debug("사용자 {}의 활성 FCM 토큰이 없습니다.", userId);
+            return;
+        }
+
+        // 각 디바이스에 전송
+        for (FcmToken token : tokens) {
+            sendSingleMessage(token.getFcmToken(), title, body);
+        }
+    }
+
+    /**
+     * 정기 러닝 알림 (모든 사용자)
+     */
+    @Transactional(readOnly = true)
+    public void sendScheduledRunningReminder(String title, String body) {
+        if (!notificationsEnabled) {
+            return;
+        }
+
+        log.info("정기 러닝 알림 전송 시작: {}", title);
+
+        List<FcmToken> allTokens = fcmTokenRepository.findAllActiveTokens();
+        List<String> validTokens = new ArrayList<>();
+
+        for (FcmToken token : allTokens) {
+            NotificationSetting setting = notificationSettingRepository.findByUserId(token.getUser().getId())
+                    .orElse(null);
+
+            if (setting != null && setting.canReceiveScheduledReminder()) {
+                validTokens.add(token.getFcmToken());
+            }
+        }
+
+        if (validTokens.isEmpty()) {
+            log.info("정기 알림을 받을 사용자가 없습니다.");
+            return;
+        }
+
+        // 멀티캐스트 전송 (최대 500개씩)
+        sendMulticastMessage(validTokens, title, body);
+        log.info("정기 러닝 알림 전송 완료: {} 사용자", validTokens.size());
+    }
+
+    /**
+     * 크루 관련 알림
+     */
+    public void sendCrewNotification(Long userId, String title, String body) {
+        if (!notificationsEnabled) {
+            return;
+        }
+
+        NotificationSetting setting = notificationSettingRepository.findByUserId(userId)
+                .orElse(null);
+
+        if (setting == null || !setting.canReceiveCrewNotification()) {
+            return;
+        }
+
+        sendNotificationToUser(userId, title, body);
+    }
+
+    /**
+     * 피드 관련 알림
+     */
+    public void sendFeedNotification(Long userId, String title, String body) {
+        if (!notificationsEnabled) {
+            return;
+        }
+
+        NotificationSetting setting = notificationSettingRepository.findByUserId(userId)
+                .orElse(null);
+
+        if (setting == null || !setting.canReceiveFeedNotification()) {
+            return;
+        }
+
+        sendNotificationToUser(userId, title, body);
+    }
+
+    /**
+     * 엠블럼 획득 알림
+     */
+    public void sendEmblemNotification(Long userId, String title, String body) {
+        if (!notificationsEnabled) {
+            return;
+        }
+
+        NotificationSetting setting = notificationSettingRepository.findByUserId(userId)
+                .orElse(null);
+
+        if (setting == null || !setting.canReceiveEmblemNotification()) {
+            return;
+        }
+
+        sendNotificationToUser(userId, title, body);
+    }
+
+    /**
+     * 단일 메시지 전송
+     */
+    private void sendSingleMessage(String token, String title, String body) {
+        try {
+            Message message = Message.builder()
+                    .setToken(token)
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .build();
+
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.debug("FCM 전송 성공: {}", response);
+
+        } catch (FirebaseMessagingException e) {
+            handleMessagingException(token, e);
+        }
+    }
+
+    /**
+     * 멀티캐스트 메시지 전송
+     */
+    private void sendMulticastMessage(List<String> tokens, String title, String body) {
+        // FCM 멀티캐스트는 최대 500개씩만 가능
+        int batchSize = 500;
+        for (int i = 0; i < tokens.size(); i += batchSize) {
+            List<String> batch = tokens.subList(i, Math.min(i + batchSize, tokens.size()));
+
+            try {
+                MulticastMessage message = MulticastMessage.builder()
+                        .addAllTokens(batch)
+                        .setNotification(Notification.builder()
+                                .setTitle(title)
+                                .setBody(body)
+                                .build())
+                        .build();
+
+                BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
+                log.debug("멀티캐스트 전송 성공: {}/{}", response.getSuccessCount(), batch.size());
+
+                // 실패한 토큰 처리
+                handleBatchResponse(batch, response);
+
+            } catch (FirebaseMessagingException e) {
+                log.error("멀티캐스트 전송 실패: {}", e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * 배치 응답 처리 (실패한 토큰 비활성화)
+     */
+    @Transactional
+    protected void handleBatchResponse(List<String> tokens, BatchResponse response) {
+        for (int i = 0; i < response.getResponses().size(); i++) {
+            SendResponse sendResponse = response.getResponses().get(i);
+            if (!sendResponse.isSuccessful()) {
+                String token = tokens.get(i);
+                FirebaseMessagingException exception = sendResponse.getException();
+                if (exception != null) {
+                    handleMessagingException(token, exception);
+                }
+            }
+        }
+    }
+
+    /**
+     * FCM 예외 처리 (무효한 토큰 비활성화)
+     */
+    @Transactional
+    protected void handleMessagingException(String token, FirebaseMessagingException e) {
+        String errorCode = e.getMessagingErrorCode() != null ? e.getMessagingErrorCode().name() : "";
+
+        if ("UNREGISTERED".equals(errorCode) || "INVALID_ARGUMENT".equals(errorCode)) {
+            log.warn("무효한 FCM 토큰 비활성화: {}", token);
+            fcmTokenRepository.deactivateToken(token);
+        } else {
+            log.error("FCM 전송 실패: {} - {}", errorCode, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/waytoearth/service/notification/NotificationScheduler.java
+++ b/src/main/java/com/waytoearth/service/notification/NotificationScheduler.java
@@ -1,0 +1,45 @@
+package com.waytoearth.service.notification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final FcmService fcmService;
+
+    @Value("${fcm.notifications.scheduled.morning-message.title}")
+    private String morningTitle;
+
+    @Value("${fcm.notifications.scheduled.morning-message.body}")
+    private String morningBody;
+
+    @Value("${fcm.notifications.scheduled.evening-message.title}")
+    private String eveningTitle;
+
+    @Value("${fcm.notifications.scheduled.evening-message.body}")
+    private String eveningBody;
+
+    /**
+     * 오전 6:30 정기 알림
+     */
+    @Scheduled(cron = "${fcm.notifications.scheduled.morning-time}", zone = "${fcm.notifications.scheduled.timezone}")
+    public void sendMorningReminder() {
+        log.info("=== 오전 러닝 알림 스케줄 실행 ===");
+        fcmService.sendScheduledRunningReminder(morningTitle, morningBody);
+    }
+
+    /**
+     * 오후 8:00 정기 알림
+     */
+    @Scheduled(cron = "${fcm.notifications.scheduled.evening-time}", zone = "${fcm.notifications.scheduled.timezone}")
+    public void sendEveningReminder() {
+        log.info("=== 저녁 러닝 알림 스케줄 실행 ===");
+        fcmService.sendScheduledRunningReminder(eveningTitle, eveningBody);
+    }
+}

--- a/src/main/java/com/waytoearth/service/notification/NotificationService.java
+++ b/src/main/java/com/waytoearth/service/notification/NotificationService.java
@@ -1,0 +1,152 @@
+package com.waytoearth.service.notification;
+
+import com.waytoearth.dto.request.notification.FcmTokenRequest;
+import com.waytoearth.dto.request.notification.NotificationSettingUpdateRequest;
+import com.waytoearth.dto.response.notification.NotificationSettingResponse;
+import com.waytoearth.entity.notification.FcmToken;
+import com.waytoearth.entity.notification.NotificationSetting;
+import com.waytoearth.entity.user.User;
+import com.waytoearth.exception.UserNotFoundException;
+import com.waytoearth.repository.notification.FcmTokenRepository;
+import com.waytoearth.repository.notification.NotificationSettingRepository;
+import com.waytoearth.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final UserRepository userRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    /**
+     * FCM 토큰 등록/갱신
+     */
+    @Transactional
+    public void registerFcmToken(Long userId, FcmTokenRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // 기존 토큰 조회
+        FcmToken existingToken = fcmTokenRepository.findByUserAndDeviceId(user, request.getDeviceId())
+                .orElse(null);
+
+        if (existingToken != null) {
+            // 토큰 갱신
+            existingToken.setFcmToken(request.getFcmToken());
+            existingToken.setDeviceType(request.getDeviceType());
+            existingToken.setIsActive(true);
+            fcmTokenRepository.save(existingToken);
+            log.info("FCM 토큰 갱신: userId={}, deviceId={}", userId, request.getDeviceId());
+        } else {
+            // 신규 토큰 등록
+            FcmToken newToken = FcmToken.builder()
+                    .user(user)
+                    .fcmToken(request.getFcmToken())
+                    .deviceId(request.getDeviceId())
+                    .deviceType(request.getDeviceType())
+                    .isActive(true)
+                    .build();
+            fcmTokenRepository.save(newToken);
+            log.info("FCM 토큰 등록: userId={}, deviceId={}", userId, request.getDeviceId());
+        }
+    }
+
+    /**
+     * FCM 토큰 비활성화 (로그아웃)
+     */
+    @Transactional
+    public void deactivateFcmToken(Long userId, String deviceId) {
+        fcmTokenRepository.deactivateUserDeviceToken(userId, deviceId);
+        log.info("FCM 토큰 비활성화: userId={}, deviceId={}", userId, deviceId);
+    }
+
+    /**
+     * 사용자의 모든 FCM 토큰 비활성화
+     */
+    @Transactional
+    public void deactivateAllUserTokens(Long userId) {
+        fcmTokenRepository.deactivateAllUserTokens(userId);
+        log.info("모든 FCM 토큰 비활성화: userId={}", userId);
+    }
+
+    /**
+     * 알림 설정 조회
+     */
+    @Transactional(readOnly = true)
+    public NotificationSettingResponse getNotificationSettings(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        NotificationSetting setting = notificationSettingRepository.findByUser(user)
+                .orElseGet(() -> createDefaultSettings(user));
+
+        return NotificationSettingResponse.builder()
+                .scheduledRunningReminder(setting.getScheduledRunningReminder())
+                .crewNotification(setting.getCrewNotification())
+                .feedNotification(setting.getFeedNotification())
+                .emblemNotification(setting.getEmblemNotification())
+                .allNotificationsEnabled(setting.getAllNotificationsEnabled())
+                .build();
+    }
+
+    /**
+     * 알림 설정 업데이트
+     */
+    @Transactional
+    public NotificationSettingResponse updateNotificationSettings(Long userId, NotificationSettingUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        NotificationSetting setting = notificationSettingRepository.findByUser(user)
+                .orElseGet(() -> createDefaultSettings(user));
+
+        // 요청에 포함된 값만 업데이트
+        if (request.getScheduledRunningReminder() != null) {
+            setting.setScheduledRunningReminder(request.getScheduledRunningReminder());
+        }
+        if (request.getCrewNotification() != null) {
+            setting.setCrewNotification(request.getCrewNotification());
+        }
+        if (request.getFeedNotification() != null) {
+            setting.setFeedNotification(request.getFeedNotification());
+        }
+        if (request.getEmblemNotification() != null) {
+            setting.setEmblemNotification(request.getEmblemNotification());
+        }
+        if (request.getAllNotificationsEnabled() != null) {
+            setting.setAllNotificationsEnabled(request.getAllNotificationsEnabled());
+        }
+
+        NotificationSetting saved = notificationSettingRepository.save(setting);
+        log.info("알림 설정 업데이트: userId={}", userId);
+
+        return NotificationSettingResponse.builder()
+                .scheduledRunningReminder(saved.getScheduledRunningReminder())
+                .crewNotification(saved.getCrewNotification())
+                .feedNotification(saved.getFeedNotification())
+                .emblemNotification(saved.getEmblemNotification())
+                .allNotificationsEnabled(saved.getAllNotificationsEnabled())
+                .build();
+    }
+
+    /**
+     * 기본 알림 설정 생성
+     */
+    private NotificationSetting createDefaultSettings(User user) {
+        NotificationSetting setting = NotificationSetting.builder()
+                .user(user)
+                .scheduledRunningReminder(true)
+                .crewNotification(true)
+                .feedNotification(true)
+                .emblemNotification(true)
+                .allNotificationsEnabled(true)
+                .build();
+        return notificationSettingRepository.save(setting);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,6 +77,23 @@ openai:
   analysis-history-limit: ${OPENAI_HISTORY_LIMIT:10}
   daily-limit-per-user: ${OPENAI_DAILY_LIMIT:10}
 
+# Firebase Cloud Messaging (FCM) 설정
+fcm:
+  firebase:
+    config-path: ${FCM_CONFIG_PATH:src/main/resources/firebase/firebase-service-account.json}
+  notifications:
+    enabled: ${FCM_ENABLED:true}
+    scheduled:
+      morning-time: "0 30 6 * * *"   # 매일 오전 6:30 (cron)
+      evening-time: "0 0 20 * * *"   # 매일 오후 8:00 (cron)
+      timezone: "Asia/Seoul"
+      morning-message:
+        title: "좋은 아침이에요! ☀️"
+        body: "오늘도 상쾌한 러닝 어때요?"
+      evening-message:
+        title: "퇴근 후 러닝 타임! 🏃"
+        body: "가벼운 러닝으로 하루를 마무리해보세요"
+
 # 캐시 설정
 cache:
   redis:


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #88 


  ### 📋 Summary
  Firebase Cloud Messaging(FCM)을 활용한 푸시 알림 시스템을 구현.
  - 정기 러닝 알림 (오전 6:30, 오후 8:00)
  - 사용자별 알림 설정 관리
  - FCM 토큰 관리 (등록/갱신/비활성화)
  - 크루/피드/엠블럼 알림 인프라

  ---

  ### 🎯 주요 기능

  #### 1. 정기 러닝 알림 스케줄러
  - **오전 6:30**: "좋은 아침이에요! ☀️ 오늘도 상쾌한 러닝 어때요?"
  - **오후 8:00**: "퇴근 후 러닝 타임! 🏃 가벼운 러닝으로 하루를 마무리해보세요"
  - Cron 표현식으로 Asia/Seoul 시간대 기준 자동 발송
  - 사용자별 알림 설정에 따라 필터링하여 전송

  #### 2. 사용자별 알림 설정
  - 정기 러닝 알림 ON/OFF
  - 크루 관련 알림 ON/OFF
  - 피드 관련 알림 ON/OFF
  - 엠블럼 획득 알림 ON/OFF
  - 전체 알림 활성화/비활성화

  #### 3. FCM 토큰 관리
  - 디바이스별 토큰 등록 (iOS/Android 구분)
  - 토큰 갱신 자동 처리
  - 로그아웃 시 토큰 비활성화
  - 무효한 토큰 자동 정리

  ---

  ### 🏗️ 구현 내용

  #### 📦 엔티티 (Entity)
```
  1. FcmToken
  @Entity
  @Table(name = "fcm_tokens")
  public class FcmToken extends BaseTimeEntity {
      private User user;              // 토큰 소유자
      private String fcmToken;         // Firebase 토큰
      private String deviceId;         // 디바이스 고유 ID
      private DeviceType deviceType;   // IOS / ANDROID
      private Boolean isActive;        // 활성화 여부
  }
  - 한 사용자가 여러 디바이스 보유 가능 (폰, 태블릿 등)
  - user_id + device_id 조합으로 unique constraint 설정
  - 로그아웃 시 isActive = false로 비활성화

  2. NotificationSetting
  @Entity
  @Table(name = "notification_settings")
  public class NotificationSetting extends BaseTimeEntity {
      private User user;                          // 설정 소유자 (1:1)
      private Boolean scheduledRunningReminder;   // 정기 알림
      private Boolean crewNotification;           // 크루 알림
      private Boolean feedNotification;           // 피드 알림
      private Boolean emblemNotification;         // 엠블럼 알림
      private Boolean allNotificationsEnabled;    // 전체 알림
  }
  - 사용자당 하나의 설정 (@OneToOne)
  - 알림 수신 가능 여부를 판단하는 헬퍼 메서드 제공
  - 기본값 모두 true (첫 가입 시 자동 생성)

  ```
 **🔧 Repository**
```
  1. FcmTokenRepository
  - findActiveTokensByUserId(): 사용자의 활성 토큰 조회
  - findAllActiveTokens(): 전체 활성 토큰 조회 (정기 알림용)
  - deactivateToken(): 특정 토큰 비활성화
  - deactivateAllUserTokens(): 사용자의 모든 토큰 비활성화

  2. NotificationSettingRepository
  - findByUser(): 사용자의 알림 설정 조회
  - findByUserId(): userId로 알림 설정 조회

  ```
  **🛠️ 서비스 (Service)**

```
  1. FcmService - FCM 메시지 전송 핵심 로직

  public class FcmService {
      // 정기 러닝 알림 (모든 사용자)
      public void sendScheduledRunningReminder(String title, String body)

      // 크루 알림
      public void sendCrewNotification(Long userId, String title, String body)

      // 피드 알림
      public void sendFeedNotification(Long userId, String title, String body)

      // 엠블럼 알림
      public void sendEmblemNotification(Long userId, String title, String body)
  }
  - Firebase Admin SDK 사용하여 메시지 전송
  - 멀티캐스트 전송 (최대 500개씩 배치 처리)
  - 무효한 토큰 감지 시 자동 비활성화 (UNREGISTERED, INVALID_ARGUMENT)
  - 알림 설정에 따라 자동 필터링

  2. NotificationService - 토큰 & 설정 관리
  public class NotificationService {
      // FCM 토큰 등록/갱신
      public void registerFcmToken(Long userId, FcmTokenRequest request)

      // FCM 토큰 비활성화
      public void deactivateFcmToken(Long userId, String deviceId)

      // 알림 설정 조회
      public NotificationSettingResponse getNotificationSettings(Long userId)

      // 알림 설정 업데이트
      public NotificationSettingResponse updateNotificationSettings(...)
  }
  - 기존 토큰 존재 시 갱신, 없으면 신규 등록
  - 알림 설정 없으면 기본값으로 자동 생성
  - 부분 업데이트 지원 (null이 아닌 필드만 수정)

  3. NotificationScheduler - 정기 알림 스케줄러
  @Component
  public class NotificationScheduler {
      @Scheduled(cron = "0 30 6 * * *", zone = "Asia/Seoul")
      public void sendMorningReminder()

      @Scheduled(cron = "0 0 20 * * *", zone = "Asia/Seoul")
      public void sendEveningReminder()
  }
  - Spring @Scheduled 활용
  - application.yml에서 cron, 메시지 내용 설정

```
  **🌐 API 엔드포인트 (Controller)**

  NotificationController - /v1/notifications

  | Method | Endpoint              | 설명              |
  |--------|-----------------------|-----------------|
  | POST   | /fcm-token            | FCM 토큰 등록/갱신    |
  | DELETE | /fcm-token/{deviceId} | 특정 디바이스 토큰 비활성화 |
  | DELETE | /fcm-token            | 모든 토큰 비활성화      |
  | GET    | /settings             | 알림 설정 조회        |
  | PATCH  | /settings             | 알림 설정 업데이트      |

  Request DTO 예시:
  // POST /v1/notifications/fcm-token
  {
    "fcmToken": "dXGfz1234...",
    "deviceId": "device-uuid-1234",
    "deviceType": "ANDROID"
  }

  // PATCH /v1/notifications/settings
  {
    "scheduledRunningReminder": true,
    "crewNotification": true,
    "feedNotification": false,
    "emblemNotification": true,
    "allNotificationsEnabled": true
  }

  ---
  **⚙️ 설정 (Configuration)**

```
  1. FcmConfig - Firebase Admin SDK 초기화
  @Configuration
  public class FcmConfig {
      @PostConstruct
      public void initialize() {
          FileInputStream serviceAccount = new FileInputStream(firebaseConfigPath);
          FirebaseOptions options = FirebaseOptions.builder()
              .setCredentials(GoogleCredentials.fromStream(serviceAccount))
              .build();
          FirebaseApp.initializeApp(options);
      }
  }

  2. application.yml 설정
  fcm:
    firebase:
      config-path: ${FCM_CONFIG_PATH:src/main/resources/firebase/firebase-service-account.json}
    notifications:
      enabled: ${FCM_ENABLED:true}
      scheduled:
        morning-time: "0 30 6 * * *"
        evening-time: "0 0 20 * * *"
        timezone: "Asia/Seoul"
        morning-message:
          title: "좋은 아침이에요! ☀️"
          body: "오늘도 상쾌한 러닝 어때요?"
        evening-message:
          title: "퇴근 후 러닝 타임! 🏃"
          body: "가벼운 러닝으로 하루를 마무리해보세요"

  ```
  **🚀 GitHub Actions 배포 설정**

  deploy.yml 수정사항:
  # 빌드 전 Firebase 설정 파일 생성
  - name: Create Firebase Service Account JSON
    run: |
      mkdir -p src/main/resources/firebase
      echo '${{ secrets.FCM_CONFIG_JSON }}' > src/main/resources/firebase/firebase-service-account.json

  # Docker 실행 시 환경변수 추가
  -e FCM_CONFIG_PATH="${{ vars.FCM_CONFIG_PATH }}" \
  -e FCM_ENABLED="${{ vars.FCM_ENABLED }}" \

  GitHub Secrets/Variables 설정 필요:
  - Secrets:
    - FCM_CONFIG_JSON: Firebase service account JSON 전체 내용
  - Variables:
    - FCM_CONFIG_PATH: src/main/resources/firebase/firebase-service-account.json
    - FCM_ENABLED: true

  ---
  🔄 동작 흐름

  1. 앱 시작 시

  클라이언트 앱 → Firebase SDK에서 FCM 토큰 발급
             → POST /v1/notifications/fcm-token
             → DB에 토큰 저장 (또는 갱신)

  2. 정기 알림 발송

  스케줄러 (6:30, 20:00) → 모든 활성 토큰 조회
                        → 사용자별 알림 설정 확인
                        → 수신 가능한 사용자만 필터링
                        → FCM 멀티캐스트 전송 (500개씩 배치)
                        → 무효한 토큰 자동 비활성화

  3. 로그아웃 시

  클라이언트 앱 → DELETE /v1/notifications/fcm-token/{deviceId}
             → DB에서 토큰 비활성화 (isActive = false)

  4. 알림 설정 변경

  사용자 → PATCH /v1/notifications/settings
       → DB 업데이트
       → 다음 알림부터 반영

  ---
  📊 DB 스키마

  **fcm_tokens 테이블**
```
  CREATE TABLE fcm_tokens (
      id BIGINT PRIMARY KEY AUTO_INCREMENT,
      user_id BIGINT NOT NULL,
      fcm_token VARCHAR(500) NOT NULL,
      device_id VARCHAR(100) NOT NULL,
      device_type VARCHAR(20),
      is_active BOOLEAN NOT NULL DEFAULT TRUE,
      created_at TIMESTAMP,
      updated_at TIMESTAMP,
      UNIQUE KEY uk_fcm_user_device (user_id, device_id),
      INDEX idx_fcm_user (user_id),
      INDEX idx_fcm_token (fcm_token),
      INDEX idx_fcm_active (is_active)
  );
```
  **notification_settings 테이블**
```
  CREATE TABLE notification_settings (
      id BIGINT PRIMARY KEY AUTO_INCREMENT,
      user_id BIGINT NOT NULL UNIQUE,
      scheduled_running_reminder BOOLEAN NOT NULL DEFAULT TRUE,
      crew_notification BOOLEAN NOT NULL DEFAULT TRUE,
      feed_notification BOOLEAN NOT NULL DEFAULT TRUE,
      emblem_notification BOOLEAN NOT NULL DEFAULT TRUE,
      all_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE,
      created_at TIMESTAMP,
      updated_at TIMESTAMP,
      INDEX idx_noti_user (user_id)
  );
```

  🧪 테스트 방법

  1. 로컬 테스트
    - Firebase service account JSON 파일 준비
    - .env에 FCM_CONFIG_PATH, FCM_ENABLED 추가
    - 스케줄러 cron 시간 변경하여 즉시 실행 테스트
  2. 실제 디바이스 테스트
    - 안드로이드/iOS 앱에서 FCM 토큰 등록
    - Firebase Console → Cloud Messaging → 테스트 메시지 전송
    - 백엔드 스케줄러로 정기 알림 확인

  ---
  🔐 보안 고려사항

  - ✅ Firebase service account JSON은 .gitignore에 포함
  - ✅ GitHub Secrets로 민감정보 관리
  - ✅ Private key 노출 방지
  - ✅ 무효한 토큰 자동 정리로 보안 강화

  ---
  📝 추가 개선 가능 사항

  - 알림 히스토리 저장 (NotificationLog 엔티티)
  - 알림 클릭 시 딥링크 연동
  - 이미지/액션 버튼이 포함된 Rich Notification
  - A/B 테스트를 위한 알림 메시지 다양화
  - 사용자 시간대별 최적 알림 시간 자동 조정

  ---
  📚 관련 파일

  엔티티:
  - FcmToken.java
  - NotificationSetting.java

  Repository:
  - FcmTokenRepository.java
  - NotificationSettingRepository.java

  서비스:
  - FcmService.java
  - NotificationService.java
  - NotificationScheduler.java

  컨트롤러:
  - NotificationController.java

  설정:
  - FcmConfig.java
  - application.yml

  DTO:
  - FcmTokenRequest.java
  - NotificationSettingUpdateRequest.java
  - NotificationSettingResponse.java

  배포:
  - .github/workflows/deploy.yml
