### PR TITLE
Fix User 엔티티의 @Version 필드 기본 값 설정 및 크루 탈퇴 시 멤버 수 업데이트

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/crew/CrewController.java
+++ b/src/main/java/com/waytoearth/controller/v1/crew/CrewController.java
@@ -188,7 +188,7 @@ public class CrewController {
 
         log.info("크루 삭제 요청 - crewId: {}, userId: {}", crewId, user.getUserId());
 
-        crewService.deleteCrew(user, crewId);
+        crewService.deleteCrew(user.getUserId(), crewId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/waytoearth/entity/user/User.java
+++ b/src/main/java/com/waytoearth/entity/user/User.java
@@ -67,7 +67,8 @@ public class User extends BaseTimeEntity {
     private Integer totalRunningCount = 0;
 
     @Version
-    private Long version;
+    @Builder.Default
+    private Long version = 0L;
 
 
     // 온보딩 완료 메서드

--- a/src/main/java/com/waytoearth/service/crew/CrewMemberServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/crew/CrewMemberServiceImpl.java
@@ -72,6 +72,9 @@ public class CrewMemberServiceImpl implements CrewMemberService {
             throw new RuntimeException("멤버 추방에 실패했습니다.");
         }
 
+        // 크루 멤버 수 감소
+        crew.decrementMemberCount();
+
         log.info("크루 멤버가 추방되었습니다. crewId: {}, targetUserId: {}, removedBy: {}",
                 crewId, targetUserId, user.getUserId());
     }
@@ -99,6 +102,9 @@ public class CrewMemberServiceImpl implements CrewMemberService {
         if (affected == 0) {
             throw new RuntimeException("크루 탈퇴에 실패했습니다.");
         }
+
+        // 크루 멤버 수 감소
+        crew.decrementMemberCount();
 
         log.info("사용자가 크루에서 탈퇴했습니다. crewId: {}, userId: {}", crewId, user.getUserId());
     }

--- a/src/main/java/com/waytoearth/service/crew/CrewMemberServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/crew/CrewMemberServiceImpl.java
@@ -93,7 +93,7 @@ public class CrewMemberServiceImpl implements CrewMemberService {
         CrewMemberEntity membership = crewMemberRepository.findMembership(user.getUserId(), crewId)
                 .orElseThrow(() -> new RuntimeException("해당 크루의 멤버가 아닙니다."));
 
-        if (!membership.getIsActive()) {
+        if (Boolean.FALSE.equals(membership.getIsActive())) {
             throw new RuntimeException("이미 탈퇴한 크루입니다.");
         }
 


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


> 이번 PR에서 작업한 내용을 간략히 설명해주세요


  1. 크루 탈퇴시 멤버 수 업데이트

  2-1. 다음 발생한 문제 초기 분석

  - 에러: Could not commit JPA transaction
  - 의심: OptimisticLockException (동시성 충돌)
  - 상황: 러닝 기록 페이지와 프로필 페이지 둘 다 PUT /v1/users/me 사용

  3-2. 실제 원인 발견

  Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because "current" is null

  - 진짜 원인: User 엔티티의 @Version 필드가 NULL
  - 왜 NULL?: 기존 DB 데이터에 version 컬럼이 NULL로 저장됨
  - 언제 발생: Hibernate가 버전 증가 시 null.longValue() 호출

  3-3. 해결 작업

  완료: Entity 수정
  // User.java:70-71
  @Version
  @Builder.Default
  private Long version = 0L;  // 기본값 추가

  TODO: DB 수정 필요
  UPDATE users SET version = 0 WHERE version IS NULL;
  ALTER TABLE users MODIFY COLUMN version BIGINT NOT NULL DEFAULT 0;

  @Version 필드 설명

  - 역할: 낙관적 락(Optimistic Locking) 구현
  - 동작: UPDATE 시 WHERE version = 조회시_버전 조건 추가
  - 목적: 동시 수정 시 데이터 정합성 보호 (Lost Update 방지)
  - 장점: 러닝 통계 업데이트와 프로필 수정이 충돌해도 데이터 일관성 유지

  다음 단계

  1. DB 수정 SQL 실행 (사용자가 직접 수행 예정)
  2. 애플리케이션 재시작
  3. 프로필 수정 테스트



---

추가 작업 사항

  해결 작업

  ✅ 완료: Entity 수정
  // User.java:70-71
  @Version
  @Builder.Default
  private Long version = 0L;  // 기본값 추가

  📋 TODO: DB 수정 필요 (사용자가 직접 수행)
  UPDATE users SET version = 0 WHERE version IS NULL;
  ALTER TABLE users MODIFY COLUMN version BIGINT NOT NULL DEFAULT 0;

   크루 탈퇴 403 에러 분석

 초기 의심

  - Security 설정 문제
  - JWT 토큰 문제

   실제 원인

  - DB 데이터 문제: crew_members.is_active와 crews.is_active가 NULL 또는 0
  - 카운트 불일치: crews.current_members = 0인데 실제 멤버 2명 존재
  - 원인: SQL로 직접 INSERT했기 때문

   해결

  -- current_members 동기화만 실행
  UPDATE crews c
  SET c.current_members = (
      SELECT COUNT(*)
      FROM crew_members cm
      WHERE cm.crew_id = c.id AND cm.is_active = 1
  );

  결과: current_members = 2로 정상화

  ---
  크루 탈퇴 로직 개선

  ✅ NULL 안전 체크 추가
  // Before
  if (!membership.getIsActive()) {  // NPE 가능

  // After (Line 96)
  if (Boolean.FALSE.equals(membership.getIsActive())) {  // NULL 안전

  파일: CrewMemberServiceImpl.java:96

  ---
   크루 가입 신청 승인 SQL 작성

  START TRANSACTION;

  -- 신청 승인 (userId=2)
  UPDATE crew_join_requests
  SET status = 'APPROVED', processed_at = NOW(),
      processed_by = 1, processing_note = '가입 승인'
  WHERE user_id = 2 AND crew_id = 1 AND status = 'PENDING';

  -- 멤버 추가
  INSERT INTO crew_members (created_at, updated_at, is_active, joined_at, role, crew_id, user_id)
  VALUES (NOW(), NOW(), 1, NOW(), 'MEMBER', 1, 2);

  -- 멤버 수 증가
  UPDATE crews SET current_members = current_members + 1 WHERE id = 1;

  COMMIT;

  ---
   크루 삭제 로직 점검 및 개선

   문제 발견

  Controller가 "간단 버전" 호출 → 연관 데이터 미처리

  수정 완료 ✅

  // CrewController.java:191
  // Before
  crewService.deleteCrew(user, crewId);  // 간단 버전 ❌

  // After
  crewService.deleteCrew(user.getUserId(), crewId);  // 완전 버전 ✅

  이제 처리되는 항목

  1. ✅ crews.is_active = false (크루 비활성화)
  2. ✅ crew_members.is_active = false (모든 멤버 비활성화)
  3. ✅ crew_join_requests.status = 'REJECTED' (대기 신청 거부)
  4. ✅ crew_statistics 정리
  5. ✅ S3 프로필 이미지 삭제

  ---
  수정된 파일 목록

  1. User.java - @Version 기본값 추가
  2. CrewMemberServiceImpl.java:96 - NULL 안전 체크
  3. CrewController.java:191 - 완전 버전 deleteCrew 호출

  ---
  남은 TODO

  1. DB 수정 필요 (사용자가 직접):
  -- users 테이블 version 초기화
  UPDATE users SET version = 0 WHERE version IS NULL;
  ALTER TABLE users MODIFY COLUMN version BIGINT NOT NULL DEFAULT 0;
  2. CrewDetail LazyInitializationException 해결 (필요시):
  // CrewServiceImpl.getCrewById()
  // findById() → findByIdWithOwner() 변경

  ---
  주요 해결 사항:
  - User version NULL 문제 (Entity 수정 완료)
  - 크루 탈퇴 NULL 안전성 (수정 완료)
  - 크루 삭제 불완전 처리 (수정 완료)


