### PR TITLE
refactor: 사용자 인증 어노테이션을 @AuthUser로 통일

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/crew/CrewController.java
+++ b/src/main/java/com/waytoearth/controller/v1/crew/CrewController.java
@@ -22,7 +22,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.waytoearth.security.AuthUser;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -43,7 +43,7 @@ public class CrewController {
     })
     @PostMapping
     public ResponseEntity<CrewDetailResponse> createCrew(
-            @AuthenticationPrincipal AuthenticatedUser user,
+            @AuthUser AuthenticatedUser user,
             @Valid @RequestBody CrewCreateRequest request) {
 
         log.info("크루 생성 요청 - userId: {}, name: {}", user.getUserId(), request.getName());
@@ -83,7 +83,7 @@ public class CrewController {
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size,
             @Parameter(description = "정렬 기준") @RequestParam(defaultValue = "createdAt") String sort,
             @Parameter(description = "정렬 방향") @RequestParam(defaultValue = "desc") String direction,
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         Sort.Direction sortDirection = direction.equalsIgnoreCase("desc")
                 ? Sort.Direction.DESC : Sort.Direction.ASC;
@@ -111,7 +111,7 @@ public class CrewController {
             @Parameter(description = "검색 키워드") @RequestParam String keyword,
             @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size,
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<CrewEntity> crews = crewService.searchCrewsByName(keyword, pageable);
@@ -134,7 +134,7 @@ public class CrewController {
     })
     @GetMapping("/my")
     public ResponseEntity<Page<CrewListResponse>> getMyCrews(
-            @AuthenticationPrincipal AuthenticatedUser user,
+            @AuthUser AuthenticatedUser user,
             @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size) {
 
@@ -157,7 +157,7 @@ public class CrewController {
     @PutMapping("/{crewId}")
     public ResponseEntity<CrewDetailResponse> updateCrew(
             @Parameter(description = "크루 ID") @PathVariable Long crewId,
-            @AuthenticationPrincipal AuthenticatedUser user,
+            @AuthUser AuthenticatedUser user,
             @Valid @RequestBody CrewUpdateRequest request) {
 
         log.info("크루 정보 수정 요청 - crewId: {}, userId: {}", crewId, user.getUserId());
@@ -184,7 +184,7 @@ public class CrewController {
     @DeleteMapping("/{crewId}")
     public ResponseEntity<Void> deleteCrew(
             @Parameter(description = "크루 ID") @PathVariable Long crewId,
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         log.info("크루 삭제 요청 - crewId: {}, userId: {}", crewId, user.getUserId());
 
@@ -203,7 +203,7 @@ public class CrewController {
     @PatchMapping("/{crewId}/toggle-status")
     public ResponseEntity<CrewDetailResponse> toggleCrewStatus(
             @Parameter(description = "크루 ID") @PathVariable Long crewId,
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         log.info("크루 상태 변경 요청 - crewId: {}, userId: {}", crewId, user.getUserId());
 

--- a/src/main/java/com/waytoearth/controller/v1/crew/CrewJoinController.java
+++ b/src/main/java/com/waytoearth/controller/v1/crew/CrewJoinController.java
@@ -20,7 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.waytoearth.security.AuthUser;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -45,7 +45,7 @@ public class CrewJoinController {
     @PostMapping("/{crewId}/join-requests")
     public ResponseEntity<JoinRequestResponse> requestToJoin(
             @Parameter(description = "크루 ID") @PathVariable Long crewId,
-            @AuthenticationPrincipal AuthenticatedUser user,
+            @AuthUser AuthenticatedUser user,
             @Valid @RequestBody CrewJoinRequest request) {
 
         log.info("크루 가입 신청 - crewId: {}, userId: {}", crewId, user.getUserId());
@@ -68,7 +68,7 @@ public class CrewJoinController {
     @PostMapping("/join-requests/{requestId}/approve")
     public ResponseEntity<Void> approveJoinRequest(
             @Parameter(description = "가입 신청 ID") @PathVariable Long requestId,
-            @AuthenticationPrincipal AuthenticatedUser user,
+            @AuthUser AuthenticatedUser user,
             @Valid @RequestBody JoinRequestProcessRequest request) {
 
         log.info("가입 신청 승인 - requestId: {}, userId: {}", requestId, user.getUserId());
@@ -89,7 +89,7 @@ public class CrewJoinController {
     @PostMapping("/join-requests/{requestId}/reject")
     public ResponseEntity<Void> rejectJoinRequest(
             @Parameter(description = "가입 신청 ID") @PathVariable Long requestId,
-            @AuthenticationPrincipal AuthenticatedUser user,
+            @AuthUser AuthenticatedUser user,
             @Valid @RequestBody JoinRequestProcessRequest request) {
 
         log.info("가입 신청 거부 - requestId: {}, userId: {}", requestId, user.getUserId());
@@ -110,7 +110,7 @@ public class CrewJoinController {
     @DeleteMapping("/join-requests/{requestId}")
     public ResponseEntity<Void> cancelJoinRequest(
             @Parameter(description = "가입 신청 ID") @PathVariable Long requestId,
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         log.info("가입 신청 취소 - requestId: {}, userId: {}", requestId, user.getUserId());
 
@@ -132,7 +132,7 @@ public class CrewJoinController {
             @Parameter(description = "신청 상태 필터") @RequestParam(required = false) CrewJoinRequestEntity.JoinRequestStatus status,
             @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size,
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
 
@@ -151,7 +151,7 @@ public class CrewJoinController {
     })
     @GetMapping("/join-requests/my")
     public ResponseEntity<List<JoinRequestResponse>> getMyJoinRequests(
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         List<CrewJoinRequestEntity> requests = crewJoinService.getUserJoinRequests(user);
 
@@ -185,7 +185,7 @@ public class CrewJoinController {
     @GetMapping("/{crewId}/join-requests/my")
     public ResponseEntity<JoinRequestResponse> getMyJoinRequestForCrew(
             @Parameter(description = "크루 ID") @PathVariable Long crewId,
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         CrewJoinRequestEntity request = crewJoinService.getUserJoinRequestForCrew(user, crewId);
 
@@ -203,7 +203,7 @@ public class CrewJoinController {
     })
     @GetMapping("/joinable")
     public ResponseEntity<List<Long>> getJoinableCrewIds(
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         List<Long> joinableCrewIds = crewJoinService.getJoinableCrewIds(user);
 
@@ -217,7 +217,7 @@ public class CrewJoinController {
     @GetMapping("/{crewId}/can-join")
     public ResponseEntity<Boolean> canJoinCrew(
             @Parameter(description = "크루 ID") @PathVariable Long crewId,
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         boolean canJoin = crewJoinService.canJoinCrew(user, crewId);
 

--- a/src/main/java/com/waytoearth/controller/v1/crew/CrewMemberController.java
+++ b/src/main/java/com/waytoearth/controller/v1/crew/CrewMemberController.java
@@ -19,7 +19,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.waytoearth.security.AuthUser;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -84,7 +84,7 @@ public class CrewMemberController {
     public ResponseEntity<Void> removeMember(
             @Parameter(description = "크루 ID") @PathVariable Long crewId,
             @Parameter(description = "추방할 사용자 ID") @PathVariable Long userId,
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         log.info("크루 멤버 추방 - crewId: {}, targetUserId: {}, requestedBy: {}",
                 crewId, userId, user.getUserId());
@@ -104,7 +104,7 @@ public class CrewMemberController {
     @DeleteMapping("/{crewId}/members/leave")
     public ResponseEntity<Void> leaveCrew(
             @Parameter(description = "크루 ID") @PathVariable Long crewId,
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         log.info("크루 탈퇴 - crewId: {}, userId: {}", crewId, user.getUserId());
 
@@ -125,7 +125,7 @@ public class CrewMemberController {
     public ResponseEntity<CrewMemberResponse> changeMemberRole(
             @Parameter(description = "크루 ID") @PathVariable Long crewId,
             @Parameter(description = "대상 사용자 ID") @PathVariable Long userId,
-            @AuthenticationPrincipal AuthenticatedUser user,
+            @AuthUser AuthenticatedUser user,
             @Valid @RequestBody MemberRoleChangeRequest request) {
 
         log.info("크루 멤버 역할 변경 - crewId: {}, targetUserId: {}, newRole: {}, requestedBy: {}",
@@ -144,7 +144,7 @@ public class CrewMemberController {
     })
     @GetMapping("/memberships/my")
     public ResponseEntity<List<CrewMemberResponse>> getMyCrewMemberships(
-            @AuthenticationPrincipal AuthenticatedUser user) {
+            @AuthUser AuthenticatedUser user) {
 
         List<CrewMemberEntity> memberships = crewMemberService.getUserCrewMemberships(user);
 
@@ -195,7 +195,7 @@ public class CrewMemberController {
     @PostMapping("/{crewId}/transfer-ownership")
     public ResponseEntity<Void> transferOwnership(
             @Parameter(description = "크루 ID") @PathVariable Long crewId,
-            @AuthenticationPrincipal AuthenticatedUser user,
+            @AuthUser AuthenticatedUser user,
             @Valid @RequestBody OwnershipTransferRequest request) {
 
         log.info("크루장 권한 이양 - crewId: {}, fromUserId: {}, toUserId: {}",


### PR DESCRIPTION
  ## #️⃣ 연관 이슈
  > #96 

  ### PR 타입(하나 이상의 PR 타입을 선택해주세요)
  - [ ] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

  > 크루 컨트롤러에서 사용자 인증 정보 주입 시 사용하는 어노테이션을 `@AuthUser`로 통일하여 코드 일관성 개선

  ## 변경 사항

  프로젝트 전반에서 사용자 인증을 위해 커스텀 어노테이션 `@AuthUser`를 사용하고 있으나, 크루 관련 3개 컨트롤러에서만 Spring Security의 표준 어노테이션인
  `@AuthenticationPrincipal`이 혼용되고 있어 코드 일관성을 해치고 있었습니다.

  두 어노테이션은 기능적으로 동일하게 동작하지만, 프로젝트의 통일된 코딩 컨벤션을 위해 모든 컨트롤러에서 `@AuthUser`를 사용하도록 통일했습니다.

  ### 수정된 파일 및 내용

  - [x] **CrewController.java** - 7개 메서드에서 `@AuthenticationPrincipal` → `@AuthUser` 변경
    - createCrew, getCrews, searchCrews, getMyCrews, updateCrew, deleteCrew, toggleCrewStatus
  - [x] **CrewMemberController.java** - 5개 메서드에서 `@AuthenticationPrincipal` → `@AuthUser` 변경
    - removeMember, leaveCrew, changeMemberRole, getMyCrewMemberships, transferOwnership
  - [x] **CrewJoinController.java** - 9개 메서드에서 `@AuthenticationPrincipal` → `@AuthUser` 변경
    - requestToJoin, approveJoinRequest, rejectJoinRequest, cancelJoinRequest, getCrewJoinRequests, getMyJoinRequests, getMyJoinRequestForCrew, getJoinableCrewIds, canJoinCrew       
  - [x] 각 파일의 import 문 수정 완료
  - [x] 빌드 및 컴파일 검증 완료

  ### 테스트 결과 or 스크린샷 (선택)
  ```bash
  # @AuthenticationPrincipal 완전 제거 확인
  $ grep -r "@AuthenticationPrincipal" src/main/java/com/waytoearth/controller/
  # 결과: 0개 (완전 제거됨)

  # @AuthUser 정상 사용 확인
  $ grep -r "@AuthUser" src/main/java/com/waytoearth/controller/
  # 결과: 30개 사용 중

  # 컴파일 성공
  $ ./gradlew compileJava
  BUILD SUCCESSFUL

  # 빌드 성공
  $ ./gradlew build -x test
  BUILD SUCCESSFUL

  💬 리뷰 요구사항 (선택)

  - API 스펙 변경 없음: 순수 내부 리팩토링으로 프론트엔드에 영향 없음을 확인해주세요
  - 일관성 검증: 3개 파일에서 import 문과 어노테이션이 일관되게 변경되었는지 검토 부탁드립니다
  - 기능 동일성: @AuthUser와 @AuthenticationPrincipal은 모두 SecurityContextHolder에서 인증 정보를 가져오므로 기능적으로 완전히 동일합니다