### PR TITLE
fix: 크루 멤버 수 동기화 오류 수정

### DIFF
--- a/src/main/java/com/waytoearth/entity/crew/CrewEntity.java
+++ b/src/main/java/com/waytoearth/entity/crew/CrewEntity.java
@@ -76,7 +76,7 @@ public class CrewEntity extends BaseTimeEntity {
 
     // 비즈니스 메서드
     public boolean isFull() {
-        return members.size() >= maxMembers;
+        return currentMembers >= maxMembers;
     }
 
     public boolean isOwner(User user) {
@@ -84,9 +84,7 @@ public class CrewEntity extends BaseTimeEntity {
     }
 
     public int getCurrentMemberCount() {
-        return (int) members.stream()
-                .filter(member -> member.getIsActive())
-                .count();
+        return currentMembers;
     }
 
     public void incrementMemberCount() {


### PR DESCRIPTION
  ## #️⃣ 연관 이슈
  > #98 98

  ### PR 타입(하나 이상의 PR 타입을 선택해주세요)
  - [ ] 기능 추가
  - [ ] 기능 삭제
  - [x] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

  > 크루 멤버 수 동기화 오류로 인한 정원 초과 문제 수정

  ## 변경 사항

  ### 문제
  크루 가입 승인 시 여러 명이 동시에 승인되면 크루 정원을 초과하여 멤버가
  추가되는 문제가 발생했습니다.

  **원인:**
  - `isFull()`은 `members` 컬렉션 크기를 체크
  - `getCurrentMemberCount()`는 스트림으로 활성 멤버 계산
  - `incrementMemberCount()`는 `currentMembers` 필드 증가
  - 세 가지 메서드가 서로 다른 데이터 소스를 사용하여 데이터 불일치 발생

  ### 해결 방법

  **CrewEntity.java 수정:**
  - [x] `isFull()` 메서드를 `currentMembers` 필드 기반으로 변경
  - [x] `getCurrentMemberCount()` 메서드를 `currentMembers` 필드 반환으로 통일       
  - [x] 모든 메서드가 동일한 데이터 소스(`currentMembers`) 사용

  ```java
  // Before
  public boolean isFull() {
      return members.size() >= maxMembers;  // 컬렉션 크기
  }

  public int getCurrentMemberCount() {
      return (int) members.stream()
              .filter(member -> member.getIsActive())
              .count();  // 스트림 계산
  }

  // After
  public boolean isFull() {
      return currentMembers >= maxMembers;  // DB 필드
  }

  public int getCurrentMemberCount() {
      return currentMembers;  // DB 필드
  }

  기대 효과

  - ✅ 동시 가입 승인 시에도 정원 초과 방지
  - ✅ 멤버 수 계산 방식 통일로 데이터 일관성 보장
  - ✅ 성능 향상 (스트림 계산 제거)

  테스트 결과 or 스크린샷 (선택)

  # 컴파일 성공
  $ ./gradlew compileJava
  BUILD SUCCESSFUL in 7s
