### PR TITLE
Fix/journey progress - 특정 여정의 진행률 조회 API 추가

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/journey/JourneyProgressController.java
+++ b/src/main/java/com/waytoearth/controller/v1/journey/JourneyProgressController.java
@@ -86,6 +86,7 @@ public class JourneyProgressController {
             - 완료된 여행 목록
             - 일시정지된 여행 목록
             - 각 여행의 진행률 및 상태
+            - 각 여행의 ID, 제목, 총 거리
             """,
         tags = {"Journey Progress API"}
     )
@@ -95,5 +96,35 @@ public class JourneyProgressController {
 
         List<JourneyProgressResponse> journeys = journeyService.getUserJourneys(userId);
         return ResponseEntity.ok(journeys);
+    }
+
+    @GetMapping("/user/{userId}/journey/{journeyId}")
+    @Operation(
+        summary = "사용자의 특정 여정 진행률 조회",
+        description = """
+            사용자의 특정 여정 진행 상황을 조회합니다.
+
+            **조회 정보:**
+            - 여정 ID 및 제목
+            - 현재 누적 거리
+            - 진행률 퍼센티지
+            - 다음 랜드마크 정보
+            - 수집한 스탬프 수
+            - 총 랜드마크 수
+
+            **사용 예시:**
+            - 여정 리스트에서 특정 여정 선택 시
+            - 해당 여정의 정확한 진행률 조회
+            """,
+        tags = {"Journey Progress API"}
+    )
+    public ResponseEntity<JourneyProgressResponse> getUserJourneyProgress(
+            @Parameter(description = "사용자 ID")
+            @PathVariable Long userId,
+            @Parameter(description = "여정 ID")
+            @PathVariable Long journeyId) {
+
+        JourneyProgressResponse progress = journeyService.getUserJourneyProgress(userId, journeyId);
+        return ResponseEntity.ok(progress);
     }
 }

--- a/src/main/java/com/waytoearth/dto/response/journey/JourneyProgressResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/journey/JourneyProgressResponse.java
@@ -8,6 +8,15 @@ public record JourneyProgressResponse(
     @Schema(description = "진행 ID", example = "1")
     Long progressId,
 
+    @Schema(description = "여정 ID", example = "1")
+    Long journeyId,
+
+    @Schema(description = "여정 제목", example = "한국의 고궁탐방")
+    String journeyTitle,
+
+    @Schema(description = "여정 총 거리 (km)", example = "12.5")
+    Double totalDistanceKm,
+
     @Schema(description = "현재 누적 거리 (km)", example = "123.4")
     Double currentDistanceKm,
 
@@ -34,6 +43,9 @@ public record JourneyProgressResponse(
     ) {
         return new JourneyProgressResponse(
             progress.getId(),
+            progress.getJourney().getId(),
+            progress.getJourney().getTitle(),
+            progress.getJourney().getTotalDistanceKm(),
             progress.getCurrentDistanceKm(),
             progress.getProgressPercent(),
             progress.getStatus().name(),

--- a/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepository.java
+++ b/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepository.java
@@ -25,6 +25,12 @@ public interface UserJourneyProgressRepository extends JpaRepository<UserJourney
     Optional<UserJourneyProgressEntity> findByUserIdAndJourneyId(Long userId, Long journeyId);
 
     /**
+     * 사용자의 특정 여행 진행 상태 조회 (Journey 정보 포함)
+     */
+    @Query("SELECT ujp FROM UserJourneyProgressEntity ujp JOIN FETCH ujp.journey WHERE ujp.user.id = :userId AND ujp.journey.id = :journeyId")
+    Optional<UserJourneyProgressEntity> findByUserIdAndJourneyIdWithJourney(@Param("userId") Long userId, @Param("journeyId") Long journeyId);
+
+    /**
      * 활성 상태인 사용자 여행 진행 목록
      */
     List<UserJourneyProgressEntity> findByUserIdAndStatus(Long userId, JourneyProgressStatus status);

--- a/src/main/java/com/waytoearth/service/journey/JourneyService.java
+++ b/src/main/java/com/waytoearth/service/journey/JourneyService.java
@@ -51,6 +51,11 @@ public interface JourneyService {
     List<JourneyProgressResponse> getUserJourneys(Long userId);
 
     /**
+     * 사용자의 특정 여정 진행률 조회
+     */
+    JourneyProgressResponse getUserJourneyProgress(Long userId, Long journeyId);
+
+    /**
      * 제목으로 여행 검색
      */
     List<JourneySummaryResponse> searchJourneysByTitle(String keyword);

--- a/src/main/java/com/waytoearth/service/journey/JourneyServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/journey/JourneyServiceImpl.java
@@ -197,6 +197,15 @@ public class JourneyServiceImpl implements JourneyService {
     }
 
     @Override
+    public JourneyProgressResponse getUserJourneyProgress(Long userId, Long journeyId) {
+        UserJourneyProgressEntity progress = progressRepository.findByUserIdAndJourneyIdWithJourney(userId, journeyId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                    "해당 사용자의 여정 진행 정보를 찾을 수 없습니다. userId: " + userId + ", journeyId: " + journeyId));
+
+        return buildProgressResponse(progress);
+    }
+
+    @Override
     public List<JourneySummaryResponse> searchJourneysByTitle(String keyword) {
         List<JourneyEntity> journeys = journeyRepository.searchByTitle(keyword);
 


### PR DESCRIPTION
##  연관 이슈
> ex) #이슈번호

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


> 이번 PR에서 작업한 내용을 간략히 설명해주세요

 추가된 내용

  1. JourneyProgressResponse에 여정 정보 추가

  - journeyId: 여정 ID
  - journeyTitle: 여정 제목
  - totalDistanceKm: 여정 총 거리

  2. 새로운 API 엔드포인트

  GET /v1/journey-progress/user/{userId}/journey/{journeyId}

  예시:
  GET /v1/journey-progress/user/1/journey/2

  응답:
  {
    "progressId": 24,
    "journeyId": 2,
    "journeyTitle": "한강 러닝 코스",
    "totalDistanceKm": 10.0,
    "currentDistanceKm": 0.0,
    "progressPercent": 0.0,
    "status": "ACTIVE",
    "nextLandmark": {
      "id": 9,
      "name": "여의도 한강공원",
      "distanceFromStart": 0.0
    },
    "collectedStamps": 0,
    "totalLandmarks": 5
  }

  3. 기존 API도 개선

  GET /v1/journey-progress/user/{userId} 응답에도 journey 정보가 포함.

  이제 해결된 문제

  프론트엔드가:
  1. 여정 2 선택
  2. GET /v1/journey-progress/user/1/journey/2 호출
  3. 여정 2의 정확한 진행률 조회 가능
  4. 여정이 시작되지 않았으면 404 에러 발생



### 테스트 결과 or 스크린샷 (선택)
> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요