### PR TITLE
Landmark/story s3 fix

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/admin/AdminLandmarkController.java
+++ b/src/main/java/com/waytoearth/controller/v1/admin/AdminLandmarkController.java
@@ -47,11 +47,11 @@ public class AdminLandmarkController {
             - 최대 10MB
 
             **S3 저장 경로:**
-            - `journeys/landmarks/{yyyy-MM-dd}/{userId}/{uuid}`
+            - `journeys/{journeyId}/landmarks/{landmarkId}/{uuid}.jpg`
 
             **사용 용도:**
             - 랜드마크 메인 이미지
-            - 랜드마크 갤러리 이미지
+            - 랜드마크 갤러리 이미지 (여러 개 가능)
             - 랜드마크 배경 이미지
             """
     )
@@ -68,9 +68,9 @@ public class AdminLandmarkController {
                       "success": true,
                       "message": "랜드마크 이미지 업로드 URL이 성공적으로 발급되었습니다.",
                       "data": {
-                        "upload_url": "https://bucket.s3.amazonaws.com/journeys/landmarks/2024-12-21/1/uuid?...",
-                        "download_url": "https://bucket.s3.amazonaws.com/journeys/landmarks/2024-12-21/1/uuid?...",
-                        "key": "journeys/landmarks/2024-12-21/1/uuid",
+                        "upload_url": "https://bucket.s3.amazonaws.com/journeys/1/landmarks/5/uuid.jpg?...",
+                        "download_url": "https://d1234567890.cloudfront.net/journeys/1/landmarks/5/uuid.jpg",
+                        "key": "journeys/1/landmarks/5/uuid.jpg",
                         "expires_in": 300
                       }
                     }
@@ -91,10 +91,12 @@ public class AdminLandmarkController {
             description = "권한 없음 (관리자 권한 필요)"
         )
     })
-    @PostMapping("/image/presign")
+    @PostMapping("/{journeyId}/{landmarkId}/image/presign")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<PresignResponse>> presignImageUpload(
             @AuthUser AuthenticatedUser user,
+            @io.swagger.v3.oas.annotations.Parameter(description = "여정 ID") @PathVariable Long journeyId,
+            @io.swagger.v3.oas.annotations.Parameter(description = "랜드마크 ID") @PathVariable Long landmarkId,
             @RequestBody(
                 description = "업로드할 파일 정보",
                 required = true,
@@ -113,10 +115,10 @@ public class AdminLandmarkController {
             )
             @Valid @org.springframework.web.bind.annotation.RequestBody PresignRequest req
     ) {
-        log.info("관리자 랜드마크 이미지 업로드 URL 발급 요청: userId={}, contentType={}, size={}",
-                user.getUserId(), req.getContentType(), req.getSize());
+        log.info("관리자 랜드마크 이미지 업로드 URL 발급 요청: userId={}, journeyId={}, landmarkId={}, contentType={}, size={}",
+                user.getUserId(), journeyId, landmarkId, req.getContentType(), req.getSize());
 
-        PresignResponse response = fileService.presignLandmark(user.getUserId(), req);
+        PresignResponse response = fileService.presignLandmark(journeyId, landmarkId, req);
 
         return ResponseEntity.ok(ApiResponse.success(response, "랜드마크 이미지 업로드 URL이 성공적으로 발급되었습니다."));
     }

--- a/src/main/java/com/waytoearth/controller/v1/admin/AdminStoryController.java
+++ b/src/main/java/com/waytoearth/controller/v1/admin/AdminStoryController.java
@@ -47,11 +47,11 @@ public class AdminStoryController {
             - 최대 10MB
 
             **S3 저장 경로:**
-            - `journeys/stories/{yyyy-MM-dd}/{userId}/{uuid}`
+            - `journeys/{journeyId}/landmarks/{landmarkId}/stories/{storyId}/{uuid}.jpg`
 
             **사용 용도:**
             - 스토리 카드 썸네일 이미지
-            - 스토리 내용 첨부 이미지
+            - 스토리 내용 첨부 이미지 (여러 개 가능)
             - 역사/문화/자연 관련 이미지
             """
     )
@@ -68,9 +68,9 @@ public class AdminStoryController {
                       "success": true,
                       "message": "스토리 이미지 업로드 URL이 성공적으로 발급되었습니다.",
                       "data": {
-                        "upload_url": "https://bucket.s3.amazonaws.com/journeys/stories/2024-12-21/1/uuid?...",
-                        "download_url": "https://bucket.s3.amazonaws.com/journeys/stories/2024-12-21/1/uuid?...",
-                        "key": "journeys/stories/2024-12-21/1/uuid",
+                        "upload_url": "https://bucket.s3.amazonaws.com/journeys/1/landmarks/5/stories/10/uuid.jpg?...",
+                        "download_url": "https://d1234567890.cloudfront.net/journeys/1/landmarks/5/stories/10/uuid.jpg",
+                        "key": "journeys/1/landmarks/5/stories/10/uuid.jpg",
                         "expires_in": 300
                       }
                     }
@@ -91,10 +91,13 @@ public class AdminStoryController {
             description = "권한 없음 (관리자 권한 필요)"
         )
     })
-    @PostMapping("/image/presign")
+    @PostMapping("/{journeyId}/{landmarkId}/{storyId}/image/presign")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<PresignResponse>> presignImageUpload(
             @AuthUser AuthenticatedUser user,
+            @io.swagger.v3.oas.annotations.Parameter(description = "여정 ID") @PathVariable Long journeyId,
+            @io.swagger.v3.oas.annotations.Parameter(description = "랜드마크 ID") @PathVariable Long landmarkId,
+            @io.swagger.v3.oas.annotations.Parameter(description = "스토리 ID") @PathVariable Long storyId,
             @RequestBody(
                 description = "업로드할 파일 정보",
                 required = true,
@@ -113,10 +116,10 @@ public class AdminStoryController {
             )
             @Valid @org.springframework.web.bind.annotation.RequestBody PresignRequest req
     ) {
-        log.info("관리자 스토리 이미지 업로드 URL 발급 요청: userId={}, contentType={}, size={}",
-                user.getUserId(), req.getContentType(), req.getSize());
+        log.info("관리자 스토리 이미지 업로드 URL 발급 요청: userId={}, journeyId={}, landmarkId={}, storyId={}, contentType={}, size={}",
+                user.getUserId(), journeyId, landmarkId, storyId, req.getContentType(), req.getSize());
 
-        PresignResponse response = fileService.presignStory(user.getUserId(), req);
+        PresignResponse response = fileService.presignStory(journeyId, landmarkId, storyId, req);
 
         return ResponseEntity.ok(ApiResponse.success(response, "스토리 이미지 업로드 URL이 성공적으로 발급되었습니다."));
     }


### PR DESCRIPTION
 ##  연관 이슈
  > #108 

  ### PR 타입(하나 이상의 PR 타입을 선택해주세요)
  - [x] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


  > 이번 PR에서 작업한 내용을 간략히 설명해주세요

  ### 주요 변경 사항
  S3 이미지 업로드 경로 구조를 여정(Journey) > 랜드마크(Landmark) > 스토리(Story) 계층으로 개선하여 그룹 관리가 가능하도록
  개선.

  ### 상세 작업 내용
  - [x] FileService.presignLandmark() 메서드 파라미터 변경 (userId → journeyId, landmarkId)
  - [x] FileService.presignStory() 메서드 파라미터 변경 (userId → journeyId, landmarkId, storyId)
  - [x] FileService에 getFileExtension() 헬퍼 메서드 추가
  - [x] FileService.validateJourneyImage() 메서드 시그니처 수정 (userId 파라미터 제거)
  - [x] AdminLandmarkController API 엔드포인트 수정 (`POST /v1/admin/landmarks/{journeyId}/{landmarkId}/image/presign`)
  - [x] AdminStoryController API 엔드포인트 수정 (`POST /v1/admin/story-cards/{journeyId}/{landmarkId}/{storyId}/image/presign`)        
  - [x] Swagger API 문서 업데이트

  ### 변경 전/후 비교

  **변경 전 S3 키 구조:**
  journeys/landmarks/{날짜}/{userId}/{UUID}
  journeys/stories/{날짜}/{userId}/{UUID}
  문제점: landmarkId/storyId 없어서 그룹 관리 불가

  **변경 후 S3 키 구조:**
  journeys/{journeyId}/landmarks/{landmarkId}/{uuid}.jpg
  journeys/{journeyId}/landmarks/{landmarkId}/stories/{storyId}/{uuid}.jpg
  개선: 계층적 폴더 구조로 그룹 관리 가능, 여러 이미지 업로드 지원

  ### 기대 효과
  - 여정별/랜드마크별/스토리별 이미지 그룹 관리 가능
  - S3 폴더 단위로 일괄 삭제 및 관리 용이
  - 랜드마크와 스토리에 여러 이미지 업로드 가능
  - CloudFront CDN 연동 유지 (prod 환경)

  ### 테스트 결과 or 스크린샷 (선택)
  - [x] 빌드 성공 확인 (`./gradlew build -x test`)
  - [ ] API 테스트 필요 (Postman/Swagger)

  ##  리뷰 요구사항 (선택)
  - Admin API 엔드포인트 경로 변경으로 인한 **Breaking Change**이므로 프론트엔드 팀 공유 필요
  - 기존 S3에 업로드된 이미지는 새 구조로 마이그레이션이 필요한지 검토 필요

