### PR TITLE
Admin

### DIFF
--- a/src/main/java/com/waytoearth/dto/response/user/UserInfoResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/user/UserInfoResponse.java
@@ -2,6 +2,7 @@ package com.waytoearth.dto.response.user;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.waytoearth.entity.enums.UserRole;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -48,11 +49,15 @@ public class UserInfoResponse {
     @Schema(description = "프로필 이미지 Key (S3 오브젝트 키)", example = "profiles/1/profile.png")
     private String profileImageKey;
 
+    @Schema(description = "사용자 역할", example = "USER", allowableValues = {"USER", "ADMIN"})
+    private String role;
+
     public UserInfoResponse() { }
 
     public UserInfoResponse(Long id, String nickname, String profileImageUrl, String residence,
                             String ageGroup, String gender, BigDecimal weeklyGoalDistance,
-                            BigDecimal totalDistance, Integer totalRunningCount, Instant createdAt, String profileImageKey) {
+                            BigDecimal totalDistance, Integer totalRunningCount, Instant createdAt,
+                            String profileImageKey, String role) {
         this.id = id;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
@@ -63,7 +68,8 @@ public class UserInfoResponse {
         this.totalDistance = totalDistance;
         this.totalRunningCount = totalRunningCount;
         this.createdAt = createdAt;
-        this.profileImageKey = profileImageKey; //추가
+        this.profileImageKey = profileImageKey;
+        this.role = role;
     }
 
 }

--- a/src/main/java/com/waytoearth/entity/enums/UserRole.java
+++ b/src/main/java/com/waytoearth/entity/enums/UserRole.java
@@ -1,0 +1,14 @@
+package com.waytoearth.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+    USER("ROLE_USER", "일반 사용자"),
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String key;
+    private final String description;
+}

--- a/src/main/java/com/waytoearth/entity/user/User.java
+++ b/src/main/java/com/waytoearth/entity/user/User.java
@@ -3,6 +3,7 @@ package com.waytoearth.entity.user;
 import com.waytoearth.entity.common.BaseTimeEntity;
 import com.waytoearth.entity.enums.AgeGroup;
 import com.waytoearth.entity.enums.Gender;
+import com.waytoearth.entity.enums.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -56,6 +57,11 @@ public class User extends BaseTimeEntity {
     @Column(name = "is_onboarding_completed", nullable = false)
     @Builder.Default
     private Boolean isOnboardingCompleted = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    @Builder.Default
+    private UserRole role = UserRole.USER;
 
     // 자동 계산 통계 필드들
     @Column(name = "total_distance", precision = 8, scale = 2)

--- a/src/main/java/com/waytoearth/security/AuthenticatedUser.java
+++ b/src/main/java/com/waytoearth/security/AuthenticatedUser.java
@@ -1,5 +1,6 @@
 package com.waytoearth.security;
 
+import com.waytoearth.entity.enums.UserRole;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,10 +8,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthenticatedUser {
     private final Long userId;
+    private final UserRole role;
 
     // 보안을 위한 toString 오버라이드 (로그에 민감정보 노출 방지)
     @Override
     public String toString() {
-        return "AuthenticatedUser{userId=" + userId + "}";
+        return "AuthenticatedUser{userId=" + userId + ", role=" + role + "}";
     }
 }

--- a/src/main/java/com/waytoearth/security/mock/MockAuthFilter.java
+++ b/src/main/java/com/waytoearth/security/mock/MockAuthFilter.java
@@ -1,5 +1,6 @@
 package com.waytoearth.security.mock;
 
+import com.waytoearth.entity.enums.UserRole;
 import com.waytoearth.security.AuthenticatedUser; // ✅ 진짜 principal import
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -45,14 +46,19 @@ public class MockAuthFilter extends OncePerRequestFilter {
                     .map(Long::valueOf)
                     .orElse(1L);
 
-            //  AuthenticatedUser는 userId 하나만 받음
-            AuthenticatedUser principal = new AuthenticatedUser(userId);
+            // Mock role (헤더로 ADMIN 설정 가능)
+            UserRole role = Optional.ofNullable(request.getHeader("X-Mock-Role"))
+                    .filter(s -> !s.isBlank())
+                    .map(UserRole::valueOf)
+                    .orElse(UserRole.USER);
+
+            AuthenticatedUser principal = new AuthenticatedUser(userId, role);
 
             UsernamePasswordAuthenticationToken auth =
                     new UsernamePasswordAuthenticationToken(
                             principal,
                             null,
-                            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                            List.of(new SimpleGrantedAuthority(role.getKey()))
                     );
             auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(auth);

--- a/src/main/java/com/waytoearth/service/file/FileService.java
+++ b/src/main/java/com/waytoearth/service/file/FileService.java
@@ -147,7 +147,9 @@ public class FileService {
     public String createPresignedGetUrl(String key) {
         // CloudFront 도메인이 설정되어 있으면 CloudFront URL 반환 (prod 환경, 만료 없음)
         if (cloudFrontDomain != null && !cloudFrontDomain.isEmpty()) {
-            return cloudFrontDomain + "/" + key;
+            // 캐시 버스팅: 타임스탬프를 쿼리 파라미터로 추가
+            long timestamp = System.currentTimeMillis();
+            return cloudFrontDomain + "/" + key + "?v=" + timestamp;
         }
 
         // CloudFront 미설정 시 S3 presigned URL 반환 (dev 환경, 5분 만료)

--- a/src/main/java/com/waytoearth/service/journey/JourneyServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/journey/JourneyServiceImpl.java
@@ -23,6 +23,7 @@ import com.waytoearth.dto.response.running.RunningStartResponse;
 import com.waytoearth.entity.enums.RunningType;
 import com.waytoearth.entity.enums.JourneyCategory;
 import com.waytoearth.entity.enums.JourneyProgressStatus;
+import com.waytoearth.entity.enums.UserRole;
 import com.waytoearth.security.AuthenticatedUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -122,7 +123,7 @@ public class JourneyServiceImpl implements JourneyService {
                 .runningType(RunningType.JOURNEY)
                 .build();
 
-        AuthenticatedUser authUser = new AuthenticatedUser(user.getId());
+        AuthenticatedUser authUser = new AuthenticatedUser(user.getId(), user.getRole());
         RunningStartResponse runningResponse = runningService.startRunning(authUser, runningRequest);
 
         // sessionId 저장
@@ -173,7 +174,7 @@ public class JourneyServiceImpl implements JourneyService {
                         .calories(request.calories())
                         .build();
 
-                AuthenticatedUser authUser = new AuthenticatedUser(progress.getUser().getId());
+                AuthenticatedUser authUser = new AuthenticatedUser(progress.getUser().getId(), progress.getUser().getRole());
                 runningService.completeRunning(authUser, runningCompleteRequest);
 
                 log.info("러닝 레코드 완료: sessionId={}, 거리={}km, 시간={}초",

--- a/src/main/java/com/waytoearth/service/user/UserService.java
+++ b/src/main/java/com/waytoearth/service/user/UserService.java
@@ -115,6 +115,8 @@ public class UserService {
             profileImageUrl = fileService.createPresignedGetUrl(u.getProfileImageKey());
         }
 
+        String role = (u.getRole() == null) ? null : u.getRole().name();
+
         return new UserInfoResponse(
                 u.getId(),
                 u.getNickname(),
@@ -126,7 +128,8 @@ public class UserService {
                 u.getTotalDistance(),
                 u.getTotalRunningCount(),
                 created,
-                u.getProfileImageKey()
+                u.getProfileImageKey(),
+                role
         );
     }
 


### PR DESCRIPTION
 ## #️⃣ 연관 이슈
  > #110 

  ### PR 타입(하나 이상의 PR 타입을 선택해주세요)
  - [x] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


  > 이번 PR에서 작업한 내용을 간략히 설명해주세요

  ### 주요 변경 사항
  일반 사용자와 관리자를 구분하여 관리자만 Admin API에 접근할 수 있도록 역할 기반 권한 시스템(RBAC)을 구현.

  ### 상세 작업 내용
  - [x] UserRole enum 생성 (`USER`, `ADMIN`)
  - [x] User 엔티티에 role 필드 추가 (기본값: `USER`)
  - [x] AuthenticatedUser에 role 필드 추가
  - [x] JwtTokenProvider - JWT 생성 시 role claim 추가
  - [x] JwtTokenProvider - JWT 검증 시 role 추출 메서드 추가 (`getRoleFromToken`)
  - [x] JwtAuthenticationFilter - Spring Security authorities 설정 (role 기반 GrantedAuthority)
  - [x] MockAuthFilter - 테스트용 role 지원 추가 (헤더: `X-Mock-Role`)
  - [x] JourneyServiceImpl - AuthenticatedUser 생성자 호출부 수정
  - [x] 빌드 테스트 완료

  ### 기술적 구현 세부사항

  **1. UserRole enum (src/main/java/com/waytoearth/entity/enums/UserRole.java)**
  ```java
  USER("ROLE_USER", "일반 사용자")
  ADMIN("ROLE_ADMIN", "관리자")

  2. JWT 토큰 구조 변경
  // 기존
  {
    "sub": "123",
    "iat": 1234567890,
    "exp": 1234654290
  }

  // 변경 후
  {
    "sub": "123",
    "role": "ADMIN",  // ← 추가
    "iat": 1234567890,
    "exp": 1234654290
  }

  3. Spring Security 권한 흐름
  JWT 토큰 검증
    → JwtTokenProvider.getRoleFromToken()
    → SimpleGrantedAuthority("ROLE_ADMIN") 생성
    → SecurityContextHolder에 authorities 설정
    → @PreAuthorize("hasRole('ADMIN')") 체크 통과

  4. 하위 호환성 유지
  - generateToken(Long userId) 메서드 오버로딩으로 기존 코드 영향 최소화
  - role 없는 기존 JWT는 자동으로 USER 역할 부여

  DB 마이그레이션 필요 (수동 실행 필요)

  -- users 테이블에 role 컬럼 추가
  ALTER TABLE users ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'USER';

  -- 기존 사용자 데이터는 자동으로 'USER' 역할 할당됨

  -- 관리자 계정 생성 예시 (필요 시)
  UPDATE users SET role = 'ADMIN' WHERE user_id = 1;

  Breaking Changes

  - AuthenticatedUser 생성자가 (Long userId, UserRole role) 형태로 변경됨
    - 영향 범위: JourneyServiceImpl, MockAuthFilter (모두 수정 완료)
  - 새로 발급되는 JWT 토큰에 role claim 포함
    - 기존 토큰도 호환됨 (role 없으면 자동으로 USER)

  테스트 결과 or 스크린샷 (선택)

  - 빌드 성공 (./gradlew build -x test)
  - Admin API 권한 테스트 필요 (Postman/Swagger)
    - X-Mock-Role: ADMIN 헤더로 테스트 가능 (postman-disabled 프로파일)
    - 실제 JWT 토큰 발급 시 role=ADMIN 포함 여부 확인 필요

  보안 체크리스트

  - SecurityConfig에서 /v1/admin/** 경로에 대해 hasRole('ADMIN') 체크 적용됨
  - JWT 토큰에서 role 추출 실패 시 기본값 USER로 안전하게 처리
  - 권한 없는 사용자가 Admin API 호출 시 403 Forbidden 반환 예상

  💬 리뷰 요구사항 (선택)

  - DB 마이그레이션: users 테이블에 role 컬럼 추가 스크립트 실행 필요
  - 관리자 계정 설정: 최초 관리자 계정을 어떻게 생성할지 논의 필요 (DB 직접 수정 vs Admin 생성 API)
  - 기존 JWT 토큰: 이미 발급된 JWT 토큰들은 role claim이 없지만, 자동으로 USER로 처리되므로 문제없음
  - 테스트 환경: Admin API 권한 체크가 정상 작동하는지 통합 테스트 필요

