### PR TITLE
 Fix: CloudFront 캐시로 인한 프로필 이미지 갱신 안되는 문제 해결

### DIFF
--- a/src/main/java/com/waytoearth/service/file/FileService.java
+++ b/src/main/java/com/waytoearth/service/file/FileService.java
@@ -64,7 +64,9 @@ public class FileService {
             default -> "bin";
         };
 
-        String key = String.format("profiles/%d/profile.%s", userId, ext);
+        // 타임스탬프를 파일명에 포함하여 CloudFront 캐시 문제 해결
+        long timestamp = System.currentTimeMillis();
+        String key = String.format("profiles/%d/profile_%d.%s", userId, timestamp, ext);
 
         String uploadUrl = createPresignedPutUrl(key, req.getContentType());
         String downloadUrl = createPresignedGetUrl(key);
@@ -231,7 +233,9 @@ public class FileService {
             default -> "bin";
         };
 
-        String key = String.format("crews/%d/profile.%s", crewId, ext);
+        // 타임스탬프를 파일명에 포함하여 CloudFront 캐시 문제 해결
+        long timestamp = System.currentTimeMillis();
+        String key = String.format("crews/%d/profile_%d.%s", crewId, timestamp, ext);
 
         String uploadUrl = createPresignedPutUrl(key, req.getContentType());
         String downloadUrl = createPresignedGetUrl(key);


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #112 


  ### 문제 상황
  - 사용자가 프로필 이미지를 변경해도 **이전 이미지가 계속 표시**되는 버그 발생
  - S3에는 새 이미지가 정상 업로드되지만, CloudFront가 이전 이미지를 캐싱하여 반환
  - 원인: 프로필 이미지 Key가 항상 동일 (`profiles/{userId}/profile.jpg`)

  ### 해결 방법
  **파일 Key에 타임스탬프를 포함하여 매번 고유한 파일명 생성**


  변경 전
 ``` String key = String.format("profiles/%d/profile.%s", userId, ext);
  // 결과: profiles/123/profile.jpg (항상 동일)
```
  변경 후
 ``` long timestamp = System.currentTimeMillis();
  String key = String.format("profiles/%d/profile_%d.%s", userId, timestamp, ext);
  // 결과: profiles/123/profile_1735526400000.jpg (매번 다름)
```
  변경 사항

  - ✅ 사용자 프로필 이미지: presignProfile() 메서드 수정
    - profiles/{userId}/profile.{ext} → profiles/{userId}/profile_{timestamp}.{ext}
  - ✅ 크루 프로필 이미지: presignCrewProfile() 메서드 수정
    - crews/{crewId}/profile.{ext} → crews/{crewId}/profile_{timestamp}.{ext}

  기술적 상세

  왜 이 방법이 확실한가?
  1. 타임스탬프 고유성: System.currentTimeMillis()는 밀리초 단위로 거의 중복 불가
  2. CloudFront 캐시 우회: 다른 파일 경로 = 새 캐시 엔트리 = 즉시 반영
  3. 설정 변경 불필요: CloudFront 캐시 정책 수정 없이 코드만으로 해결

  테스트

  - 빌드 성공 (./gradlew clean build)
  - 실제 프로필 이미지 변경 테스트 필요

  부작용 및 고려사항

  장점:
  - ✅ 캐시 문제 완전 해결
  - ✅ CloudFront 설정 변경 불필요
  - ✅ 즉시 적용 가능

  단점:
  - ⚠️ S3에 이전 프로필 이미지 파일들이 누적됨
  - 💡 해결: S3 Lifecycle Policy로 오래된 파일 자동 삭제 설정 권장
    - 예: 30일 이상 된 profiles/*/profile_*.{ext} 파일 자동 삭제

  관련 파일

  - src/main/java/com/waytoearth/service/file/FileService.java
