### PR TITLE
[feat] Admin story - admin 전용 api 생성 (스토리 생성, 삭제, 수정)

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/admin/AdminStoryController.java
+++ b/src/main/java/com/waytoearth/controller/v1/admin/AdminStoryController.java
@@ -1,11 +1,15 @@
 package com.waytoearth.controller.v1.admin;
 
 import com.waytoearth.dto.request.file.PresignRequest;
+import com.waytoearth.dto.request.journey.StoryCardCreateRequest;
+import com.waytoearth.dto.request.journey.StoryCardUpdateRequest;
 import com.waytoearth.dto.response.common.ApiResponse;
 import com.waytoearth.dto.response.file.PresignResponse;
+import com.waytoearth.dto.response.journey.StoryCardResponse;
 import com.waytoearth.security.AuthUser;
 import com.waytoearth.security.AuthenticatedUser;
 import com.waytoearth.service.file.FileService;
+import com.waytoearth.service.journey.StoryCardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -16,6 +20,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -29,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdminStoryController {
 
     private final FileService fileService;
+    private final StoryCardService storyCardService;
 
     @Operation(
         summary = "스토리 이미지 업로드 Presigned URL 발급 (관리자 전용)",
@@ -91,6 +97,122 @@ public class AdminStoryController {
             description = "권한 없음 (관리자 권한 필요)"
         )
     })
+    @Operation(
+        summary = "스토리 카드 생성 (관리자 전용)",
+        description = """
+            관리자가 특정 랜드마크에 새로운 스토리 카드를 생성합니다.
+
+            **권한:**
+            - 관리자만 접근 가능
+
+            **스토리 타입:**
+            - HISTORY: 역사 관련 스토리
+            - CULTURE: 문화 관련 스토리
+            - NATURE: 자연 관련 스토리
+
+            **순서 관리:**
+            - orderIndex로 스토리 표시 순서 제어
+            - 0부터 시작하며, 작은 숫자가 먼저 표시됨
+            """
+    )
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "201",
+            description = "스토리 카드 생성 성공"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (필수 값 누락, 유효성 검증 실패)"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "랜드마크를 찾을 수 없음"
+        )
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<StoryCardResponse>> createStoryCard(
+            @AuthUser AuthenticatedUser user,
+            @Valid @org.springframework.web.bind.annotation.RequestBody StoryCardCreateRequest request
+    ) {
+        log.info("관리자 스토리 카드 생성 요청: userId={}, landmarkId={}, title={}",
+                user.getUserId(), request.landmarkId(), request.title());
+
+        StoryCardResponse response = storyCardService.createStoryCard(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "스토리 카드가 성공적으로 생성되었습니다."));
+    }
+
+    @Operation(
+        summary = "스토리 카드 수정 (관리자 전용)",
+        description = """
+            관리자가 기존 스토리 카드의 정보를 수정합니다.
+
+            **권한:**
+            - 관리자만 접근 가능
+
+            **수정 가능 항목:**
+            - 제목, 내용, 이미지 URL, 타입, 순서
+            """
+    )
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "스토리 카드 수정 성공"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "스토리 카드를 찾을 수 없음"
+        )
+    })
+    @PutMapping("/{storyId}")
+    public ResponseEntity<ApiResponse<StoryCardResponse>> updateStoryCard(
+            @AuthUser AuthenticatedUser user,
+            @io.swagger.v3.oas.annotations.Parameter(description = "스토리 카드 ID") @PathVariable Long storyId,
+            @Valid @org.springframework.web.bind.annotation.RequestBody StoryCardUpdateRequest request
+    ) {
+        log.info("관리자 스토리 카드 수정 요청: userId={}, storyId={}, title={}",
+                user.getUserId(), storyId, request.title());
+
+        StoryCardResponse response = storyCardService.updateStoryCard(storyId, request);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "스토리 카드가 성공적으로 수정되었습니다."));
+    }
+
+    @Operation(
+        summary = "스토리 카드 삭제 (관리자 전용)",
+        description = """
+            관리자가 스토리 카드를 삭제합니다.
+
+            **권한:**
+            - 관리자만 접근 가능
+
+            **주의:**
+            - 삭제된 스토리 카드는 복구할 수 없습니다
+            """
+    )
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "스토리 카드 삭제 성공"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "스토리 카드를 찾을 수 없음"
+        )
+    })
+    @DeleteMapping("/{storyId}")
+    public ResponseEntity<ApiResponse<Void>> deleteStoryCard(
+            @AuthUser AuthenticatedUser user,
+            @io.swagger.v3.oas.annotations.Parameter(description = "스토리 카드 ID") @PathVariable Long storyId
+    ) {
+        log.info("관리자 스토리 카드 삭제 요청: userId={}, storyId={}", user.getUserId(), storyId);
+
+        storyCardService.deleteStoryCard(storyId);
+
+        return ResponseEntity.ok(ApiResponse.success(null, "스토리 카드가 성공적으로 삭제되었습니다."));
+    }
+
     @PostMapping("/{journeyId}/{landmarkId}/{storyId}/image/presign")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<PresignResponse>> presignImageUpload(

--- a/src/main/java/com/waytoearth/dto/request/journey/StoryCardCreateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/journey/StoryCardCreateRequest.java
@@ -1,0 +1,34 @@
+package com.waytoearth.dto.request.journey;
+
+import com.waytoearth.entity.enums.StoryType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
+@Schema(description = "스토리 카드 생성 요청")
+public record StoryCardCreateRequest(
+    @NotNull(message = "랜드마크 ID는 필수입니다")
+    @Schema(description = "랜드마크 ID", example = "1")
+    Long landmarkId,
+
+    @NotBlank(message = "제목은 필수입니다")
+    @Size(max = 100, message = "제목은 100자 이하여야 합니다")
+    @Schema(description = "스토리 제목", example = "에펠탑의 역사")
+    String title,
+
+    @NotBlank(message = "내용은 필수입니다")
+    @Size(max = 2000, message = "내용은 2000자 이하여야 합니다")
+    @Schema(description = "스토리 내용", example = "에펠탑은 1889년 파리 만국박람회를 기념하여 건설되었습니다...")
+    String content,
+
+    @Schema(description = "이미지 URL", example = "https://cdn.waytoearth.com/stories/eiffel-tower.jpg")
+    String imageUrl,
+
+    @NotNull(message = "스토리 타입은 필수입니다")
+    @Schema(description = "스토리 타입", example = "HISTORY", allowableValues = {"HISTORY", "CULTURE", "NATURE"})
+    StoryType type,
+
+    @NotNull(message = "정렬 순서는 필수입니다")
+    @Min(value = 0, message = "정렬 순서는 0 이상이어야 합니다")
+    @Schema(description = "정렬 순서 (0부터 시작)", example = "0")
+    Integer orderIndex
+) {}

--- a/src/main/java/com/waytoearth/dto/request/journey/StoryCardUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/journey/StoryCardUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.waytoearth.dto.request.journey;
+
+import com.waytoearth.entity.enums.StoryType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
+@Schema(description = "스토리 카드 수정 요청")
+public record StoryCardUpdateRequest(
+    @NotBlank(message = "제목은 필수입니다")
+    @Size(max = 100, message = "제목은 100자 이하여야 합니다")
+    @Schema(description = "스토리 제목", example = "에펠탑의 역사")
+    String title,
+
+    @NotBlank(message = "내용은 필수입니다")
+    @Size(max = 2000, message = "내용은 2000자 이하여야 합니다")
+    @Schema(description = "스토리 내용", example = "에펠탑은 1889년 파리 만국박람회를 기념하여 건설되었습니다...")
+    String content,
+
+    @Schema(description = "이미지 URL", example = "https://cdn.waytoearth.com/stories/eiffel-tower.jpg")
+    String imageUrl,
+
+    @NotNull(message = "스토리 타입은 필수입니다")
+    @Schema(description = "스토리 타입", example = "HISTORY", allowableValues = {"HISTORY", "CULTURE", "NATURE"})
+    StoryType type,
+
+    @NotNull(message = "정렬 순서는 필수입니다")
+    @Min(value = 0, message = "정렬 순서는 0 이상이어야 합니다")
+    @Schema(description = "정렬 순서 (0부터 시작)", example = "0")
+    Integer orderIndex
+) {}

--- a/src/main/java/com/waytoearth/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/waytoearth/exception/GlobalExceptionHandler.java
@@ -159,6 +159,38 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
     }
 
+    @ExceptionHandler(StoryCardNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleStoryCardNotFoundException(StoryCardNotFoundException e) {
+        log.error("스토리 카드 없음 예외: {}", e.getMessage());
+
+        ErrorResponse response = ErrorResponse.builder()
+                .success(false)
+                .error(ErrorDetail.builder()
+                        .code("STORY_CARD_NOT_FOUND")
+                        .message(e.getMessage())
+                        .build())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(LandmarkNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleLandmarkNotFoundException(LandmarkNotFoundException e) {
+        log.error("랜드마크 없음 예외: {}", e.getMessage());
+
+        ErrorResponse response = ErrorResponse.builder()
+                .success(false)
+                .error(ErrorDetail.builder()
+                        .code("LANDMARK_NOT_FOUND")
+                        .message(e.getMessage())
+                        .build())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception e) {
         log.error("예상치 못한 서버 오류", e);

--- a/src/main/java/com/waytoearth/exception/LandmarkNotFoundException.java
+++ b/src/main/java/com/waytoearth/exception/LandmarkNotFoundException.java
@@ -1,0 +1,14 @@
+package com.waytoearth.exception;
+
+/**
+ * 랜드마크를 찾을 수 없을 때 발생하는 예외
+ */
+public class LandmarkNotFoundException extends RuntimeException {
+    public LandmarkNotFoundException(String message) {
+        super(message);
+    }
+
+    public LandmarkNotFoundException(Long landmarkId) {
+        super("랜드마크를 찾을 수 없습니다: " + landmarkId);
+    }
+}

--- a/src/main/java/com/waytoearth/exception/StoryCardNotFoundException.java
+++ b/src/main/java/com/waytoearth/exception/StoryCardNotFoundException.java
@@ -1,0 +1,14 @@
+package com.waytoearth.exception;
+
+/**
+ * 스토리 카드를 찾을 수 없을 때 발생하는 예외
+ */
+public class StoryCardNotFoundException extends RuntimeException {
+    public StoryCardNotFoundException(String message) {
+        super(message);
+    }
+
+    public StoryCardNotFoundException(Long storyCardId) {
+        super("스토리 카드를 찾을 수 없습니다: " + storyCardId);
+    }
+}

--- a/src/main/java/com/waytoearth/service/journey/StoryCardService.java
+++ b/src/main/java/com/waytoearth/service/journey/StoryCardService.java
@@ -1,0 +1,44 @@
+package com.waytoearth.service.journey;
+
+import com.waytoearth.dto.request.journey.StoryCardCreateRequest;
+import com.waytoearth.dto.request.journey.StoryCardUpdateRequest;
+import com.waytoearth.dto.response.journey.StoryCardResponse;
+
+/**
+ * 스토리 카드 서비스 인터페이스
+ * 스토리 카드 CRUD 작업을 처리합니다.
+ */
+public interface StoryCardService {
+
+    /**
+     * 스토리 카드 생성
+     *
+     * @param request 스토리 카드 생성 요청
+     * @return 생성된 스토리 카드 응답
+     */
+    StoryCardResponse createStoryCard(StoryCardCreateRequest request);
+
+    /**
+     * 스토리 카드 수정
+     *
+     * @param storyId 스토리 카드 ID
+     * @param request 스토리 카드 수정 요청
+     * @return 수정된 스토리 카드 응답
+     */
+    StoryCardResponse updateStoryCard(Long storyId, StoryCardUpdateRequest request);
+
+    /**
+     * 스토리 카드 삭제
+     *
+     * @param storyId 스토리 카드 ID
+     */
+    void deleteStoryCard(Long storyId);
+
+    /**
+     * 스토리 카드 조회
+     *
+     * @param storyId 스토리 카드 ID
+     * @return 스토리 카드 응답
+     */
+    StoryCardResponse getStoryCard(Long storyId);
+}

--- a/src/main/java/com/waytoearth/service/journey/StoryCardServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/journey/StoryCardServiceImpl.java
@@ -1,0 +1,99 @@
+package com.waytoearth.service.journey;
+
+import com.waytoearth.dto.request.journey.StoryCardCreateRequest;
+import com.waytoearth.dto.request.journey.StoryCardUpdateRequest;
+import com.waytoearth.dto.response.journey.StoryCardResponse;
+import com.waytoearth.entity.journey.LandmarkEntity;
+import com.waytoearth.entity.journey.StoryCardEntity;
+import com.waytoearth.exception.LandmarkNotFoundException;
+import com.waytoearth.exception.StoryCardNotFoundException;
+import com.waytoearth.repository.journey.LandmarkRepository;
+import com.waytoearth.repository.journey.StoryCardRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 스토리 카드 서비스 구현체
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class StoryCardServiceImpl implements StoryCardService {
+
+    private final StoryCardRepository storyCardRepository;
+    private final LandmarkRepository landmarkRepository;
+
+    @Override
+    @Transactional
+    public StoryCardResponse createStoryCard(StoryCardCreateRequest request) {
+        log.info("스토리 카드 생성 요청: landmarkId={}, title={}, type={}",
+                request.landmarkId(), request.title(), request.type());
+
+        // 랜드마크 존재 확인
+        LandmarkEntity landmark = landmarkRepository.findById(request.landmarkId())
+                .orElseThrow(() -> new LandmarkNotFoundException(request.landmarkId()));
+
+        // 스토리 카드 생성
+        StoryCardEntity storyCard = StoryCardEntity.builder()
+                .landmark(landmark)
+                .title(request.title())
+                .content(request.content())
+                .imageUrl(request.imageUrl())
+                .type(request.type())
+                .orderIndex(request.orderIndex())
+                .build();
+
+        StoryCardEntity savedStoryCard = storyCardRepository.save(storyCard);
+        log.info("스토리 카드 생성 완료: storyCardId={}", savedStoryCard.getId());
+
+        return StoryCardResponse.from(savedStoryCard);
+    }
+
+    @Override
+    @Transactional
+    public StoryCardResponse updateStoryCard(Long storyId, StoryCardUpdateRequest request) {
+        log.info("스토리 카드 수정 요청: storyId={}, title={}", storyId, request.title());
+
+        // 스토리 카드 존재 확인
+        StoryCardEntity storyCard = storyCardRepository.findById(storyId)
+                .orElseThrow(() -> new StoryCardNotFoundException(storyId));
+
+        // 스토리 카드 수정
+        storyCard.setTitle(request.title());
+        storyCard.setContent(request.content());
+        storyCard.setImageUrl(request.imageUrl());
+        storyCard.setType(request.type());
+        storyCard.setOrderIndex(request.orderIndex());
+
+        StoryCardEntity updatedStoryCard = storyCardRepository.save(storyCard);
+        log.info("스토리 카드 수정 완료: storyCardId={}", updatedStoryCard.getId());
+
+        return StoryCardResponse.from(updatedStoryCard);
+    }
+
+    @Override
+    @Transactional
+    public void deleteStoryCard(Long storyId) {
+        log.info("스토리 카드 삭제 요청: storyId={}", storyId);
+
+        // 스토리 카드 존재 확인
+        StoryCardEntity storyCard = storyCardRepository.findById(storyId)
+                .orElseThrow(() -> new StoryCardNotFoundException(storyId));
+
+        storyCardRepository.delete(storyCard);
+        log.info("스토리 카드 삭제 완료: storyCardId={}", storyId);
+    }
+
+    @Override
+    public StoryCardResponse getStoryCard(Long storyId) {
+        log.info("스토리 카드 조회 요청: storyId={}", storyId);
+
+        StoryCardEntity storyCard = storyCardRepository.findById(storyId)
+                .orElseThrow(() -> new StoryCardNotFoundException(storyId));
+
+        return StoryCardResponse.from(storyCard);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


> 이번 PR에서 작업한 내용을 간략히 설명해주세요

 구현 완료 사항

   생성된 파일

  1. Request DTOs
    - StoryCardCreateRequest.java - 스토리 생성 요청
    - StoryCardUpdateRequest.java - 스토리 수정 요청
  2. Service Layer
    - StoryCardService.java - 서비스 인터페이스
    - StoryCardServiceImpl.java - 서비스 구현체
  3. Exception Handlers
    - StoryCardNotFoundException.java - 스토리 카드 없음 예외
    - LandmarkNotFoundException.java - 랜드마크 없음 예외
    - GlobalExceptionHandler.java - 예외 핸들러 추가
  4. Controller
    - AdminStoryController.java - CRUD 엔드포인트 추가

  ---
   API 엔드포인트

  관리자 전용 API (모두 ADMIN 권한 필요)

  | Method | Endpoint                                                               | 설명             |
  |--------|------------------------------------------------------------------------|----------------|
  | POST   | /v1/admin/story-cards                                                  | 스토리 생성         |
  | PUT    | /v1/admin/story-cards/{storyId}                                        | 스토리 수정         |
  | DELETE | /v1/admin/story-cards/{storyId}                                        | 스토리 삭제         |
  | POST   | /v1/admin/story-cards/{journeyId}/{landmarkId}/{storyId}/image/presign | 이미지 업로드 URL 발급 |

  ---
   사용 예시

  1. 스토리 생성

  POST /v1/admin/story-cards
  Authorization: Bearer <admin-token>
  Content-Type: application/json

  {
    "landmarkId": 1,
    "title": "에펠탑의 역사",
    "content": "에펠탑은 1889년 파리 만국박람회를 기념하여 건설되었습니다...",
    "imageUrl": "https://cdn.waytoearth.com/stories/eiffel-tower.jpg",
    "type": "HISTORY",
    "orderIndex": 0
  }

  응답:
  {
    "success": true,
    "message": "스토리 카드가 성공적으로 생성되었습니다.",
    "data": {
      "id": 10,
      "title": "에펠탑의 역사",
      "content": "에펠탑은 1889년 파리 만국박람회를 기념하여...",
      "imageUrl": "https://cdn.waytoearth.com/stories/eiffel-tower.jpg",
      "type": "HISTORY",
      "orderIndex": 0
    },
    "timestamp": "2024-01-01T12:00:00Z",
    "errorCode": null
  }

  2. 스토리 수정

  PUT /v1/admin/story-cards/10
  Authorization: Bearer <admin-token>
  Content-Type: application/json

  {
    "title": "에펠탑의 역사 (수정)",
    "content": "에펠탑은 1889년 파리 만국박람회를 기념하여 건설되었으며...",
    "imageUrl": "https://cdn.waytoearth.com/stories/eiffel-tower-v2.jpg",
    "type": "HISTORY",
    "orderIndex": 0
  }

  3. 스토리 삭제

  DELETE /v1/admin/story-cards/10
  Authorization: Bearer <admin-token>

  응답:
  {
    "success": true,
    "message": "스토리 카드가 성공적으로 삭제되었습니다.",
    "data": null,
    "timestamp": "2024-01-01T12:00:00Z",
    "errorCode": null
  }

  ---
   주요 기능

   검증 기능

  - 제목: 필수, 최대 100자
  - 내용: 필수, 최대 2000자
  - 타입: 필수 (HISTORY, CULTURE, NATURE)
  - 순서: 필수, 0 이상
  - 랜드마크 존재 확인

   권한 관리

  - 모든 CRUD 작업은 ADMIN 권한 필요
  - @PreAuthorize("hasRole('ADMIN')") 적용

   예외 처리

  - 스토리 카드 없음 → 404 (STORY_CARD_NOT_FOUND)
  - 랜드마크 없음 → 404 (LANDMARK_NOT_FOUND)
  - 유효성 검증 실패 → 400 (INVALID_PARAMETER)

   스토리 타입

  - HISTORY (역사) - 역사적 사건, 인물, 배경
  - CULTURE (문화) - 문화유산, 전통, 예술
  - NATURE (자연) - 자연경관, 생태계, 지리

  ---
   관련 파일 위치

  - DTOs: src/main/java/com/waytoearth/dto/request/journey/
  - Service: src/main/java/com/waytoearth/service/journey/
  - Controller: src/main/java/com/waytoearth/controller/v1/admin/AdminStoryController.java:1
  - Exceptions: src/main/java/com/waytoearth/exception/


### 테스트 결과 or 스크린샷 (선택)
> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요