### PR TITLE
feat : WeatherCurrentResponse DTO에 temperature 필드 추가,  WeatherServiceImpl 온도 파싱 로직 추가

### DIFF
--- a/src/main/java/com/waytoearth/dto/response/weather/WeatherCurrentResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/weather/WeatherCurrentResponse.java
@@ -23,6 +23,9 @@ public class WeatherCurrentResponse {
     @Schema(description = "날씨 이모지", example = "☁️")
     private String emoji;
 
+    @Schema(description = "현재 온도(°C)", example = "23.5")
+    private Double temperature;
+
     @Schema(description = "조회 시각")
     private LocalDateTime fetchedAt;
 
@@ -34,6 +37,7 @@ public class WeatherCurrentResponse {
                 .condition(c)
                 .emoji(c.getEmoji())
                 .iconCode(null)
+                .temperature(null)
                 .fetchedAt(LocalDateTime.now())
                 .recommendation(c.getRecommendation())
                 .build();

--- a/src/main/java/com/waytoearth/service/weather/WeatherServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/weather/WeatherServiceImpl.java
@@ -43,12 +43,19 @@ public class WeatherServiceImpl implements WeatherService {
             String main = root.path("weather").get(0).path("main").asText("");
             String icon = root.path("weather").get(0).path("icon").asText(""); // e.g. "10d"
 
+            // 온도 정보 파싱 (units=metric이므로 섭씨 온도)
+            Double temperature = null;
+            if (root.has("main") && root.path("main").has("temp")) {
+                temperature = root.path("main").path("temp").asDouble();
+            }
+
             WeatherCondition condition = WeatherCondition.fromOpenWeatherMain(main);
 
             return WeatherCurrentResponse.builder()
                     .condition(condition)
                     .emoji(condition.getEmoji())
                     .iconCode(icon) // 프론트가 자체 아이콘 쓰면 무시해도 OK
+                    .temperature(temperature)
                     .fetchedAt(LocalDateTime.now())
                     .recommendation(condition.getRecommendation()) // 아래 DTO 참고
                     .build();


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


> 이번 PR에서 작업한 내용을 간략히 설명해주세요

 변경 사항

  1. WeatherCurrentResponse.java (DTO)

  - temperature 필드 추가 (Double 타입, 섭씨 온도)
  - Swagger 문서에 "현재 온도(°C)" 설명 추가

  2. WeatherServiceImpl.java (서비스)

  - OpenWeather API에서 main.temp 값을 파싱하는 로직 추가
  - 온도 정보가 없을 경우 null로 안전하게 처리

  3. WEATHER_API_GUIDE.md (문서)

  - 응답에 temperature 필드 추가 (예시: 23.5)
  - 온도 정보 활용 예시 추가:
    - 온도별 색상 코딩
    - 온도별 러닝 복장 추천 로직

  응답 예시

  {
    "success": true,
    "message": "현재 날씨 정보를 성공적으로 조회했습니다.",
    "data": {
      "condition": "CLEAR",
      "iconCode": "01d",
      "emoji": "☀️",
      "temperature": 23.5,  // ← 새로 추가된 온도 정보 (섭씨)
      "fetchedAt": "2025-10-21T14:30:00",
      "recommendation": "맑아요! 모자와 선크림 준비하고 가볍게 달려요."
    }
  }



### 테스트 결과 or 스크린샷 (선택)
> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요