### PR TITLE
fix: 크루 프로필 CloudFront URL 지원 및 S3 403 오류 해결

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/crew/CrewController.java
+++ b/src/main/java/com/waytoearth/controller/v1/crew/CrewController.java
@@ -34,6 +34,7 @@ public class CrewController {
 
     private final CrewService crewService;
     private final CrewJoinService crewJoinService;
+    private final com.waytoearth.service.file.FileService fileService;
 
     @Operation(summary = "크루 생성", description = "새로운 크루를 생성합니다. 생성자가 자동으로 크루장이 됩니다.")
     @ApiResponses({
@@ -57,7 +58,7 @@ public class CrewController {
         );
 
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(CrewDetailResponse.from(crew));
+                .body(CrewDetailResponse.from(crew, fileService));
     }
 
     @Operation(summary = "크루 상세 조회", description = "특정 크루의 상세 정보를 조회합니다.")
@@ -70,7 +71,7 @@ public class CrewController {
             @Parameter(description = "크루 ID") @PathVariable Long crewId) {
 
         CrewEntity crew = crewService.getCrewById(crewId);
-        return ResponseEntity.ok(CrewDetailResponse.from(crew));
+        return ResponseEntity.ok(CrewDetailResponse.from(crew, fileService));
     }
 
     @Operation(summary = "크루 목록 조회", description = "활성화된 모든 크루 목록을 페이징하여 조회합니다.")
@@ -96,7 +97,7 @@ public class CrewController {
             if (user != null) {
                 canJoin = crewJoinService.canJoinCrew(user, crew.getId());
             }
-            return CrewListResponse.from(crew, canJoin);
+            return CrewListResponse.from(crew, canJoin, fileService);
         });
 
         return ResponseEntity.ok(response);
@@ -121,7 +122,7 @@ public class CrewController {
             if (user != null) {
                 canJoin = crewJoinService.canJoinCrew(user, crew.getId());
             }
-            return CrewListResponse.from(crew, canJoin);
+            return CrewListResponse.from(crew, canJoin, fileService);
         });
 
         return ResponseEntity.ok(response);
@@ -141,7 +142,7 @@ public class CrewController {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<CrewEntity> crews = crewService.getUserCrews(user, pageable);
 
-        Page<CrewListResponse> response = crews.map(crew -> CrewListResponse.from(crew, false));
+        Page<CrewListResponse> response = crews.map(crew -> CrewListResponse.from(crew, false, fileService));
 
         return ResponseEntity.ok(response);
     }
@@ -168,10 +169,11 @@ public class CrewController {
                 request.getName(),
                 request.getDescription(),
                 request.getMaxMembers(),
-                request.getProfileImageUrl()
+                request.getProfileImageUrl(),
+                request.getProfileImageKey()
         );
 
-        return ResponseEntity.ok(CrewDetailResponse.from(crew));
+        return ResponseEntity.ok(CrewDetailResponse.from(crew, fileService));
     }
 
     @Operation(summary = "크루 삭제", description = "크루를 삭제합니다. 크루장만 가능합니다.")
@@ -209,6 +211,6 @@ public class CrewController {
 
         CrewEntity crew = crewService.toggleCrewStatus(user, crewId);
 
-        return ResponseEntity.ok(CrewDetailResponse.from(crew));
+        return ResponseEntity.ok(CrewDetailResponse.from(crew, fileService));
     }
 }

--- a/src/main/java/com/waytoearth/dto/request/crew/CrewUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/crew/CrewUpdateRequest.java
@@ -29,6 +29,9 @@ public class CrewUpdateRequest {
     @Schema(description = "최대 인원", example = "20")
     private Integer maxMembers;
 
-    @Schema(description = "프로필 이미지 URL", example = "https://example.com/crew-profile.jpg")
+    @Schema(description = "프로필 이미지 URL (deprecated, profileImageKey 사용 권장)", example = "https://example.com/crew-profile.jpg")
     private String profileImageUrl;
+
+    @Schema(description = "프로필 이미지 S3 Key", example = "crews/123/profile_1234567890.jpg")
+    private String profileImageKey;
 }

--- a/src/main/java/com/waytoearth/dto/response/crew/CrewDetailResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/crew/CrewDetailResponse.java
@@ -1,6 +1,7 @@
 package com.waytoearth.dto.response.crew;
 
 import com.waytoearth.entity.crew.CrewEntity;
+import com.waytoearth.service.file.FileService;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -47,6 +48,33 @@ public class CrewDetailResponse {
     @Schema(description = "수정일", example = "2024-01-15T10:30:00")
     private LocalDateTime updatedAt;
 
+    public static CrewDetailResponse from(CrewEntity crew, FileService fileService) {
+        // profileImageKey가 있으면 CloudFront URL 생성, 없으면 기존 profileImageUrl 사용
+        String profileImageUrl = null;
+        if (crew.getProfileImageKey() != null && !crew.getProfileImageKey().isEmpty()) {
+            profileImageUrl = fileService.createPresignedGetUrl(crew.getProfileImageKey());
+        } else if (crew.getProfileImageUrl() != null) {
+            // 기존 데이터 호환성 (key가 없는 경우)
+            profileImageUrl = crew.getProfileImageUrl();
+        }
+
+        return new CrewDetailResponse(
+                crew.getId(),
+                crew.getName(),
+                crew.getDescription(),
+                crew.getMaxMembers(),
+                crew.getCurrentMembers(),
+                profileImageUrl,
+                crew.getIsActive(),
+                crew.getOwner().getId(),
+                crew.getOwner().getNickname(),
+                crew.getCreatedAt(),
+                crew.getUpdatedAt()
+        );
+    }
+
+    // 기존 메서드 유지 (하위 호환성)
+    @Deprecated
     public static CrewDetailResponse from(CrewEntity crew) {
         return new CrewDetailResponse(
                 crew.getId(),

--- a/src/main/java/com/waytoearth/dto/response/crew/CrewListResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/crew/CrewListResponse.java
@@ -1,6 +1,7 @@
 package com.waytoearth.dto.response.crew;
 
 import com.waytoearth.entity.crew.CrewEntity;
+import com.waytoearth.service.file.FileService;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/waytoearth/dto/response/crew/CrewListResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/crew/CrewListResponse.java
@@ -42,6 +42,31 @@ public class CrewListResponse {
     @Schema(description = "가입 가능 여부", example = "true")
     private Boolean canJoin;
 
+    public static CrewListResponse from(CrewEntity crew, Boolean canJoin, FileService fileService) {
+        // profileImageKey가 있으면 CloudFront URL 생성, 없으면 기존 profileImageUrl 사용
+        String profileImageUrl = null;
+        if (crew.getProfileImageKey() != null && !crew.getProfileImageKey().isEmpty()) {
+            profileImageUrl = fileService.createPresignedGetUrl(crew.getProfileImageKey());
+        } else if (crew.getProfileImageUrl() != null) {
+            // 기존 데이터 호환성 (key가 없는 경우)
+            profileImageUrl = crew.getProfileImageUrl();
+        }
+
+        return new CrewListResponse(
+                crew.getId(),
+                crew.getName(),
+                crew.getDescription(),
+                crew.getMaxMembers(),
+                crew.getCurrentMembers(),
+                profileImageUrl,
+                crew.getOwner().getNickname(),
+                crew.getCreatedAt(),
+                canJoin
+        );
+    }
+
+    // 기존 메서드 유지 (하위 호환성)
+    @Deprecated
     public static CrewListResponse from(CrewEntity crew, Boolean canJoin) {
         return new CrewListResponse(
                 crew.getId(),
@@ -56,6 +81,7 @@ public class CrewListResponse {
         );
     }
 
+    @Deprecated
     public static CrewListResponse from(CrewEntity crew) {
         return from(crew, null);
     }

--- a/src/main/java/com/waytoearth/entity/crew/CrewEntity.java
+++ b/src/main/java/com/waytoearth/entity/crew/CrewEntity.java
@@ -41,8 +41,12 @@ public class CrewEntity extends BaseTimeEntity {
     @Builder.Default
     private Integer maxMembers = 50;
 
-    @Schema(description = "프로필 이미지 URL", example = "https://example.com/crew-profile.jpg")
+    @Schema(description = "프로필 이미지 URL (deprecated, CloudFront URL 사용 권장)", example = "https://example.com/crew-profile.jpg")
     private String profileImageUrl;
+
+    @Schema(description = "프로필 이미지 S3 Key", example = "crews/123/profile_1234567890.jpg")
+    @Column(name = "profile_image_key", length = 512)
+    private String profileImageKey;
 
     @Schema(description = "활성화 상태", example = "true")
     @Column(nullable = false)

--- a/src/main/java/com/waytoearth/service/crew/CrewService.java
+++ b/src/main/java/com/waytoearth/service/crew/CrewService.java
@@ -32,7 +32,7 @@ public interface CrewService {
      * 크루 정보 수정 (크루장만 가능)
      */
     CrewEntity updateCrew(AuthenticatedUser user, Long crewId, String name,
-                         String description, Integer maxMembers, String profileImageUrl);
+                         String description, Integer maxMembers, String profileImageUrl, String profileImageKey);
 
     /**
      * 크루 삭제 (크루장만 가능)

--- a/src/main/java/com/waytoearth/service/file/FileService.java
+++ b/src/main/java/com/waytoearth/service/file/FileService.java
@@ -138,7 +138,7 @@ public class FileService {
                 .bucket(bucket)
                 .key(key)
                 .contentType(contentType)
-                .cacheControl("no-cache, no-store, must-revalidate") // CloudFront 캐시 방지
+                // cache-control은 GET 요청에만 필요, PUT(업로드)에는 불필요하며 서명 불일치 원인이 됨
                 .build();
 
         PutObjectPresignRequest presignReq = PutObjectPresignRequest.builder()


### PR DESCRIPTION
## 🧩 Summary

- 크루 프로필 이미지에 **CloudFront 영구 URL 지원** 추가  
- User/Feed 이미지와 동일한 방식으로 통합  
- **기존 데이터와 하위 호환성 유지**  
- **S3 Presigned URL 서명 불일치(403)** 문제 해결

---

##  주요 변경사항

### 1. **CrewEntity**
- `profileImageKey` 필드 추가 (S3 Object Key 저장용)
- `profileImageUrl`은 deprecated 처리 (하위 호환성 유지)

### 2. **Response DTO 개선**
- `CrewDetailResponse`, `CrewListResponse`에 `FileService` 파라미터 추가  
- CloudFront URL을 런타임에서 동적으로 생성  
- 기존 getter 메서드는 `@Deprecated`로 표시하여 하위 호환 유지

### 3. **Controller & Service 업데이트**
- `CrewController`에 `FileService` 의존성 주입  
- 모든 응답에서 `FileService`를 통해 CloudFront URL 생성  
- `updateCrew()` 메서드에 `profileImageKey` 파라미터 추가

### 4. **이미지 삭제 로직 개선**
- `removeCrewProfileImage()`에서 `profileImageKey` 우선 사용  
- 기존 데이터는 URL에서 S3 Key를 추출하여 삭제  
- URL 및 Key 모두 DB에서 제거 처리

### 5. **FileService 수정 (핵심)**
- Presigned PUT URL 생성 시 **`cache-control` 헤더 제거**
- 프론트엔드 업로드 시 발생하던 **403 `SignatureDoesNotMatch` 에러 해결**
- `cache-control`은 **GET 요청(다운로드)**에만 필요하며  
  **PUT 요청(업로드)**에는 불필요 → 서명 검증 일관성 확보

---

## ⚙️ 기술적 배경: S3 Presigned URL 서명 메커니즘

### 문제 상황
- 프론트엔드에서 S3 업로드 실패 (HTTP 403 `SignatureDoesNotMatch`)

### 원인
1. 백엔드가 Presigned URL 생성 시 `cache-control` 헤더를 서명에 포함  
2. 프론트엔드 업로드 시 빈 헤더 전송  
3. AWS S3가 서명 검증 시 불일치 감지 → 403 발생

### 해결 방법
- PUT 요청에는 `cache-control` 제외  
- `Content-Type`만 서명에 포함하여 프론트엔드와 일관성 확보  
- GET 요청 시 캐시 제어는 CloudFront에서 처리

---

##  동작 방식 요약

1. 신규 데이터 → `profileImageKey` 저장 → CloudFront URL 생성  
2. 기존 데이터 → `profileImageUrl` 사용 (하위 호환성 유지)  
3. 삭제 시 → `profileImageKey` 우선, 없으면 URL에서 Key 추출  
4. 업로드 시 → 간소화된 서명으로 403 방지

---

##  배포 시 주의사항

- `ddl-auto: update` 설정으로 컬럼 자동 추가 (`profile_image_key`)  
- 서버 재시작 시 `crews` 테이블 자동 갱신  
- 기존 크루 데이터는 그대로 정상 동작  
- FileService 수정으로 **모든 이미지 업로드(프로필, 피드, 크루 등)** 403 오류 해결

---

##  Test Plan

- [ ] 크루 생성 시 `profileImageKey` 기반 업로드 확인  
- [ ] 크루 조회 시 CloudFront URL 정상 반환  
- [ ] 크루 수정 시 `profileImageKey` 업데이트 정상 반영  
- [ ] 기존 크루 데이터 조회 정상 동작 (하위 호환성 확인)  
- [ ] 크루 프로필 이미지 삭제 정상 동작  
- [ ] S3 업로드 시 403 `SignatureDoesNotMatch` 미발생 확인  
- [ ] 프로필 / 피드 / 랜드마크 / 스토리 이미지 업로드 전체 정상 동작

---

##  변경된 파일 목록

- `CrewEntity.java` – `profileImageKey` 필드 추가  
- `CrewDetailResponse.java` – CloudFront URL 생성 로직 추가  
- `CrewListResponse.java` – CloudFront URL 생성 로직 추가  
- `CrewController.java` – `FileService` 의존성 주입  
- `CrewService.java` – 메서드 시그니처 업데이트  
- `CrewServiceImpl.java` – `updateCrew`, `removeCrewProfileImage` 수정  
- `CrewUpdateRequest.java` – `profileImageKey` 필드 추가  
- `FileService.java` – Presigned PUT URL 서명 로직 수정 (403 에러 해결)
