### PR TITLE
feat: 크루/멤버 랭킹에 프로필 이미지 CloudFront 지원 및 삭제 시 Redis 동기화

### DIFF
--- a/src/main/java/com/waytoearth/dto/response/crew/CrewMemberRankingDto.java
+++ b/src/main/java/com/waytoearth/dto/response/crew/CrewMemberRankingDto.java
@@ -6,6 +6,7 @@ public class CrewMemberRankingDto {
     private final String month;
     private final Long userId;
     private final String userName;
+    private final String profileImageUrl;
     private final BigDecimal totalDistance;
     private final Integer runCount;
     private final Integer rank;
@@ -15,6 +16,18 @@ public class CrewMemberRankingDto {
         this.month = month;
         this.userId = userId;
         this.userName = userName;
+        this.profileImageUrl = null;
+        this.totalDistance = totalDistance;
+        this.runCount = runCount;
+        this.rank = rank;
+    }
+
+    public CrewMemberRankingDto(String month, Long userId, String userName, String profileImageUrl,
+                               BigDecimal totalDistance, Integer runCount, Integer rank) {
+        this.month = month;
+        this.userId = userId;
+        this.userName = userName;
+        this.profileImageUrl = profileImageUrl;
         this.totalDistance = totalDistance;
         this.runCount = runCount;
         this.rank = rank;
@@ -24,6 +37,7 @@ public class CrewMemberRankingDto {
     public String getMonth() { return month; }
     public Long getUserId() { return userId; }
     public String getUserName() { return userName; }
+    public String getProfileImageUrl() { return profileImageUrl; }
     public BigDecimal getTotalDistance() { return totalDistance; }
     public Integer getRunCount() { return runCount; }
     public Integer getRank() { return rank; }

--- a/src/main/java/com/waytoearth/dto/response/crew/CrewRankingDto.java
+++ b/src/main/java/com/waytoearth/dto/response/crew/CrewRankingDto.java
@@ -6,6 +6,7 @@ public class CrewRankingDto {
     private final String month;
     private final Long crewId;
     private final String crewName;
+    private final String profileImageUrl;
     private final BigDecimal totalDistance;
     private final Integer runCount;
     private final Integer rank;
@@ -15,6 +16,18 @@ public class CrewRankingDto {
         this.month = month;
         this.crewId = crewId;
         this.crewName = crewName;
+        this.profileImageUrl = null;
+        this.totalDistance = totalDistance;
+        this.runCount = runCount;
+        this.rank = rank;
+    }
+
+    public CrewRankingDto(String month, Long crewId, String crewName, String profileImageUrl,
+                         BigDecimal totalDistance, Integer runCount, Integer rank) {
+        this.month = month;
+        this.crewId = crewId;
+        this.crewName = crewName;
+        this.profileImageUrl = profileImageUrl;
         this.totalDistance = totalDistance;
         this.runCount = runCount;
         this.rank = rank;
@@ -24,6 +37,7 @@ public class CrewRankingDto {
     public String getMonth() { return month; }
     public Long getCrewId() { return crewId; }
     public String getCrewName() { return crewName; }
+    public String getProfileImageUrl() { return profileImageUrl; }
     public BigDecimal getTotalDistance() { return totalDistance; }
     public Integer getRunCount() { return runCount; }
     public Integer getRank() { return rank; }

--- a/src/main/java/com/waytoearth/service/crew/CrewServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/crew/CrewServiceImpl.java
@@ -36,6 +36,7 @@ public class CrewServiceImpl implements CrewService {
     private final FileService fileService;
     private final com.waytoearth.repository.crew.CrewChatNotificationSettingRepository crewChatNotificationSettingRepository;
     private final com.waytoearth.repository.crew.CrewChatRepository crewChatRepository;
+    private final com.waytoearth.service.ranking.CrewRankingService crewRankingService;
 
     @Override
     @Transactional
@@ -245,7 +246,10 @@ public class CrewServiceImpl implements CrewService {
         crewStatisticsService.cleanupStatisticsForCrew(crewId);
         crewChatNotificationSettingRepository.deleteAllByCrew_Id(crewId);
 
-        // 3. 크루 물리 삭제 (CASCADE로 멤버, 가입신청 자동 삭제)
+        // 3. Redis 랭킹 데이터 삭제
+        crewRankingService.removeCrewFromAllRankings(crewId);
+
+        // 4. 크루 물리 삭제 (CASCADE로 멤버, 가입신청 자동 삭제)
         // 채팅 메시지는 ON DELETE SET NULL로 자동으로 crew_id가 NULL이 됨 (메시지 보존)
         crewRepository.deleteById(crewId);
 

--- a/src/main/java/com/waytoearth/service/ranking/CrewRankingService.java
+++ b/src/main/java/com/waytoearth/service/ranking/CrewRankingService.java
@@ -56,4 +56,9 @@ public interface CrewRankingService {
      * DB 데이터로 Redis 랭킹 재구축
      */
     void rebuildRankingFromDB(String month);
+
+    /**
+     * 크루 삭제 시 모든 월의 Redis 랭킹 데이터 삭제
+     */
+    void removeCrewFromAllRankings(Long crewId);
 }

--- a/src/main/java/com/waytoearth/service/ranking/CrewRankingServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/ranking/CrewRankingServiceImpl.java
@@ -30,6 +30,7 @@ public class CrewRankingServiceImpl implements CrewRankingService {
     private final CrewStatisticsRepository statisticsRepository;
     private final UserRepository userRepository;
     private final CrewRepository crewRepository;
+    private final com.waytoearth.service.file.FileService fileService;
 
     @Override
     public List<CrewMemberRankingDto> getMemberRankingInCrew(Long crewId, String month, int limit) {
@@ -219,8 +220,42 @@ public class CrewRankingServiceImpl implements CrewRankingService {
                 member.getTotalDistance().doubleValue());
         }
 
+        // 프로필 이미지 URL 추가 (DB 조회 시에는 없으므로 추가)
+        List<Long> userIds = ranking.stream()
+            .map(CrewMemberRankingDto::getUserId)
+            .toList();
+
+        List<User> users = userRepository.findAllById(userIds);
+        Map<Long, User> userMap = users.stream()
+            .collect(java.util.stream.Collectors.toMap(User::getId, user -> user));
+
+        // 프로필 이미지를 포함한 새로운 DTO 리스트 생성
+        List<CrewMemberRankingDto> enrichedRanking = new ArrayList<>();
+        for (CrewMemberRankingDto member : ranking) {
+            User user = userMap.get(member.getUserId());
+            String profileImageUrl = null;
+
+            if (user != null) {
+                if (user.getProfileImageKey() != null && !user.getProfileImageKey().isEmpty()) {
+                    profileImageUrl = fileService.createPresignedGetUrl(user.getProfileImageKey());
+                } else if (user.getProfileImageUrl() != null) {
+                    profileImageUrl = user.getProfileImageUrl();
+                }
+            }
+
+            enrichedRanking.add(new CrewMemberRankingDto(
+                member.getMonth(),
+                member.getUserId(),
+                member.getUserName(),
+                profileImageUrl,
+                member.getTotalDistance(),
+                member.getRunCount(),
+                member.getRank()
+            ));
+        }
+
         log.info("DB에서 조회한 멤버 랭킹을 Redis에 캐싱했습니다. crewId: {}, month: {}", crewId, month);
-        return ranking;
+        return enrichedRanking;
     }
 
     private List<CrewRankingDto> getCrewRankingFromDB(String month, int limit) {
@@ -251,8 +286,8 @@ public class CrewRankingServiceImpl implements CrewRankingService {
             .toList();
 
         List<User> users = userRepository.findAllById(userIds);
-        Map<Long, String> userNicknameMap = users.stream()
-            .collect(java.util.stream.Collectors.toMap(User::getId, User::getNickname));
+        Map<Long, User> userMap = users.stream()
+            .collect(java.util.stream.Collectors.toMap(User::getId, user -> user));
 
         // Redis에서 러닝 횟수 조회
         Map<Long, Integer> runCountMap = new HashMap<>();
@@ -265,12 +300,21 @@ public class CrewRankingServiceImpl implements CrewRankingService {
             Long userId = Long.valueOf(tuple.getValue().toString());
             Double totalDistance = tuple.getScore();
 
-            String nickname = userNicknameMap.get(userId);
-            if (nickname != null) {
+            User user = userMap.get(userId);
+            if (user != null) {
+                // profileImageKey가 있으면 CloudFront URL 생성, 없으면 기존 URL 사용
+                String profileImageUrl = null;
+                if (user.getProfileImageKey() != null && !user.getProfileImageKey().isEmpty()) {
+                    profileImageUrl = fileService.createPresignedGetUrl(user.getProfileImageKey());
+                } else if (user.getProfileImageUrl() != null) {
+                    profileImageUrl = user.getProfileImageUrl();
+                }
+
                 ranking.add(new CrewMemberRankingDto(
                     month,
                     userId,
-                    nickname,
+                    user.getNickname(),
+                    profileImageUrl,
                     BigDecimal.valueOf(totalDistance),
                     runCountMap.getOrDefault(userId, 0),
                     rank++
@@ -294,8 +338,8 @@ public class CrewRankingServiceImpl implements CrewRankingService {
             .toList();
 
         List<CrewEntity> crews = crewRepository.findAllById(crewIds);
-        Map<Long, String> crewNameMap = crews.stream()
-            .collect(java.util.stream.Collectors.toMap(CrewEntity::getId, CrewEntity::getName));
+        Map<Long, CrewEntity> crewMap = crews.stream()
+            .collect(java.util.stream.Collectors.toMap(CrewEntity::getId, crew -> crew));
 
         // Redis에서 러닝 횟수 조회
         Map<Long, Integer> runCountMap = new HashMap<>();
@@ -308,15 +352,30 @@ public class CrewRankingServiceImpl implements CrewRankingService {
             Long crewId = Long.valueOf(tuple.getValue().toString());
             Double totalDistance = tuple.getScore();
 
-            String crewName = crewNameMap.getOrDefault(crewId, "알 수 없는 크루");
-            ranking.add(new CrewRankingDto(
-                month,
-                crewId,
-                crewName,
-                BigDecimal.valueOf(totalDistance),
-                runCountMap.getOrDefault(crewId, 0),
-                rank++
-            ));
+            CrewEntity crew = crewMap.get(crewId);
+            if (crew != null) {
+                // profileImageKey가 있으면 CloudFront URL 생성, 없으면 기존 URL 사용
+                String profileImageUrl = null;
+                if (crew.getProfileImageKey() != null && !crew.getProfileImageKey().isEmpty()) {
+                    profileImageUrl = fileService.createPresignedGetUrl(crew.getProfileImageKey());
+                } else if (crew.getProfileImageUrl() != null) {
+                    profileImageUrl = crew.getProfileImageUrl();
+                }
+
+                ranking.add(new CrewRankingDto(
+                    month,
+                    crewId,
+                    crew.getName(),
+                    profileImageUrl,
+                    BigDecimal.valueOf(totalDistance),
+                    runCountMap.getOrDefault(crewId, 0),
+                    rank++
+                ));
+            } else {
+                // 크루가 삭제된 경우 (Redis에는 남아있지만 DB에는 없음)
+                log.warn("크루 랭킹에 삭제된 크루가 포함되어 있습니다. crewId: {}, month: {}", crewId, month);
+                // 삭제된 크루는 랭킹에서 제외
+            }
         }
 
         return ranking;


### PR DESCRIPTION


## 🧩 Summary

- **크루 랭킹**에 프로필 이미지 **CloudFront URL 지원** 추가  
- **크루 멤버 랭킹**에도 프로필 이미지 **CloudFront URL 지원** 추가  
- **크루 삭제 시 Redis 랭킹 데이터 자동 삭제**  
- **크루 이름/프로필 변경 시 조회 시점 최신 정보 자동 반영**

---

## 주요 변경사항

### 1. **크루 랭킹 프로필 이미지 추가**
- `CrewRankingDto`에 `profileImageUrl` 필드 추가  
- Redis 조회 시 `CrewEntity.profileImageKey` 기반으로 CloudFront URL 동적 생성  
- DB 조회 시에도 프로필 이미지 포함  
- 기존 생성자 및 구조는 그대로 유지 (하위 호환성 보장)

### 2. **크루 멤버 랭킹 프로필 이미지 추가**
- `CrewMemberRankingDto`에 `profileImageUrl` 필드 추가  
- Redis 조회 시 `User.profileImageKey`로 CloudFront URL 생성  
- DB 조회 시에도 프로필 이미지 포함  
- 기존 필드/생성자와의 호환성 유지

### 3. **크루 삭제 시 Redis 랭킹 데이터 자동 삭제**
- `CrewRankingService.removeCrewFromAllRankings()` 메서드 추가  
- 과거 12개월치 Redis ZSet 및 Hash 데이터에서 해당 크루 자동 제거  
- `CrewServiceImpl.deleteCrew()`에서 자동 호출  
- 삭제된 크루가 랭킹에 잔존하는 문제 해결

### 4. **크루 정보 변경 시 즉시 반영**
- **이름 변경**: 조회 시마다 DB에서 최신 이름 조회 (기존 로직 유지)  
- **프로필 이미지 변경**: 조회 시 `profileImageKey` 기반으로 CloudFront URL 재생성  
- **삭제된 크루**: Redis 조회 시 DB에 존재하지 않으면 자동 제외

---

## ⚙️ 기술적 구현

### CloudFront URL 생성 로직

```java
// profileImageKey 우선 사용 (CloudFront)
if (crew.getProfileImageKey() != null && !crew.getProfileImageKey().isEmpty()) {
    profileImageUrl = fileService.createPresignedGetUrl(crew.getProfileImageKey());
    // ex) https://cdn.waytoearth.cloud/crews/1/profile.jpg?v=timestamp
}
// 기존 profileImageUrl 사용 (하위 호환)
else if (crew.getProfileImageUrl() != null) {
    profileImageUrl = crew.getProfileImageUrl();
}


### Redis 랭킹 데이터 삭제

```java
// 크루 삭제 시 과거 12개월 치 랭킹 데이터 제거
for (int i = 0; i < 12; i++) {
    String month = currentMonth.minusMonths(i).format("yyyyMM");
    redisTemplate.opsForZSet().remove(crewRankingKey(month), crewId.toString());
    redisTemplate.opsForHash().delete(crewRunCountKey(month), crewId.toString());
}
```

---

## 🧾 API 응답 예시

### 크루 랭킹 (수정 후)

```json
[
  {
    "rank": 1,
    "crewId": 5,
    "crewName": "서울 러닝 크루",
    "profileImageUrl": "https://cdn.waytoearth.cloud/crews/5/profile_123.jpg?v=1234567",
    "totalDistance": 500.5,
    "runCount": 120,
    "month": "202510"
  }
]
```

### 크루 멤버 랭킹 (수정 후)

```json
[
  {
    "rank": 1,
    "userId": 123,
    "userName": "홍길동",
    "profileImageUrl": "https://cdn.waytoearth.cloud/profiles/123/profile.jpg?v=1234567",
    "totalDistance": 100.5,
    "runCount": 20,
    "month": "202510"
  }
]
```

---

## 동작 흐름

1. **Redis 조회** → `crewId` 및 거리 데이터 가져오기
2. **DB 조회** → 최신 `CrewEntity`에서 이름 및 `profileImageKey` 조회
3. **CloudFront URL 생성** → S3 키 기반 영구 URL 생성
4. **응답 반환** → 이름, 이미지, 거리, 횟수 포함

**크루 변경 반영**

* 이름 변경 → 다음 조회 시 자동 반영
* 이미지 변경 → 다음 조회 시 CloudFront URL 갱신
* 크루 삭제 → Redis에서 제거되어 랭킹에 표시되지 않음

---

## ✅ Test Plan

* [ ] 크루 랭킹 조회 시 프로필 이미지 정상 표시
* [ ] 크루 멤버 랭킹 조회 시 멤버 프로필 이미지 정상 표시
* [ ] 크루 이름 변경 후 랭킹 재조회 시 변경된 이름 반영
* [ ] 크루 프로필 이미지 변경 후 재조회 시 새 이미지 반영
* [ ] 크루 삭제 후 랭킹에서 제거 확인
* [ ] Redis 조회 시 CloudFront URL 정상 생성 확인
* [ ] DB 조회 시 CloudFront URL 정상 생성 확인
* [ ] 삭제된 크루가 랭킹에 남지 않는지 검증

---

## 변경된 파일

* `CrewRankingDto.java` — `profileImageUrl` 필드 추가
* `CrewMemberRankingDto.java` — `profileImageUrl` 필드 추가
* `CrewRankingService.java` — `removeCrewFromAllRankings()` 인터페이스 추가
* `CrewRankingServiceImpl.java` — CloudFront URL 생성 및 Redis 삭제 로직 추가
* `CrewServiceImpl.java` — 크루 삭제 시 Redis 랭킹 자동 제거 로직 추가



