### PR TITLE
feat: 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/user/UserController.java
+++ b/src/main/java/com/waytoearth/controller/v1/user/UserController.java
@@ -82,4 +82,17 @@ public class UserController {
 
         return ResponseEntity.ok(ApiResponse.success("프로필이 성공적으로 수정되었습니다."));
     }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "현재 로그인한 사용자의 계정 및 모든 연관 데이터를 삭제합니다. 이 작업은 되돌릴 수 없습니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> deleteAccount(@AuthUser AuthenticatedUser me) {
+        log.info("[Users:Delete] 회원 탈퇴 요청 - userId: {}", me.getUserId());
+        userService.deleteUser(me.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.success("회원 탈퇴가 완료되었습니다."));
+    }
 }

--- a/src/main/java/com/waytoearth/repository/crew/CrewJoinRequestRepository.java
+++ b/src/main/java/com/waytoearth/repository/crew/CrewJoinRequestRepository.java
@@ -83,4 +83,9 @@ public interface CrewJoinRequestRepository extends JpaRepository<CrewJoinRequest
            "ORDER BY jr.processedAt DESC")
     List<CrewJoinRequestEntity> findByCrewAndStatusWithProcessor(@Param("crew") CrewEntity crew,
                                                                   @Param("status") JoinRequestStatus status);
+
+    /**
+     * 사용자 ID로 크루 가입 신청 일괄 삭제 (회원 탈퇴용)
+     */
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/crew/CrewMemberRepository.java
+++ b/src/main/java/com/waytoearth/repository/crew/CrewMemberRepository.java
@@ -103,4 +103,7 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
            "JOIN FETCH cm.user " +
            "WHERE cm.crew.id = :crewId AND cm.isActive = true AND cm.role = 'MEMBER'")
     Page<CrewMemberEntity> findRegularMembersWithPaging(@Param("crewId") Long crewId, Pageable pageable);
+
+    // 사용자 ID로 크루 멤버십 일괄 삭제 (회원 탈퇴용)
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/emblem/UserEmblemRepository.java
+++ b/src/main/java/com/waytoearth/repository/emblem/UserEmblemRepository.java
@@ -39,4 +39,7 @@ public interface UserEmblemRepository extends JpaRepository<UserEmblem, Long> {
             "where ue.user.id = :userId and ue.emblem.id in :emblemIds")
     List<UserEmblem> findByUserIdAndEmblemIdIn(@Param("userId") Long userId,
                                                @Param("emblemIds") List<Long> emblemIds);
+
+    /** 사용자 ID로 엠블럼 일괄 삭제 (회원 탈퇴용) */
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/feed/FeedLikeRepository.java
+++ b/src/main/java/com/waytoearth/repository/feed/FeedLikeRepository.java
@@ -14,4 +14,6 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     void deleteByFeedAndUser(Feed feed, User user);
     void deleteByFeed(Feed feed);
 
+    // 사용자 ID로 피드 좋아요 일괄 삭제 (회원 탈퇴용)
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/feed/FeedRepository.java
+++ b/src/main/java/com/waytoearth/repository/feed/FeedRepository.java
@@ -46,4 +46,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositor
            "LEFT JOIN FETCH f.runningRecord " +
            "ORDER BY f.createdAt DESC")
     List<Feed> findAllWithUserAndRecordOrderByCreatedAtDesc(Pageable pageable);
+
+    // 사용자 ID로 피드 일괄 삭제 (회원 탈퇴용)
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/journey/GuestbookRepository.java
+++ b/src/main/java/com/waytoearth/repository/journey/GuestbookRepository.java
@@ -42,4 +42,9 @@ public interface GuestbookRepository extends JpaRepository<GuestbookEntity, Long
      */
     @Query("SELECT g FROM GuestbookEntity g JOIN FETCH g.user JOIN FETCH g.landmark WHERE g.isPublic = true ORDER BY g.createdAt DESC")
     Page<GuestbookEntity> findRecentPublicGuestbook(Pageable pageable);
+
+    /**
+     * 사용자 ID로 방명록 일괄 삭제 (회원 탈퇴용)
+     */
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepository.java
+++ b/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepository.java
@@ -81,4 +81,9 @@ public interface UserJourneyProgressRepository extends JpaRepository<UserJourney
      */
     @Query("SELECT COUNT(ujp) FROM UserJourneyProgressEntity ujp WHERE ujp.journey.id = :journeyId AND ujp.status = 'COMPLETED'")
     Long countCompletedRunnersByJourneyId(@Param("journeyId") Long journeyId);
+
+    /**
+     * 사용자 ID로 여행 진행 내역 일괄 삭제 (회원 탈퇴용)
+     */
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/notification/FcmTokenRepository.java
+++ b/src/main/java/com/waytoearth/repository/notification/FcmTokenRepository.java
@@ -48,4 +48,9 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     @Modifying
     @Query("UPDATE FcmToken f SET f.isActive = false WHERE f.user.id = :userId AND f.deviceId = :deviceId")
     int deactivateUserDeviceToken(@Param("userId") Long userId, @Param("deviceId") String deviceId);
+
+    /**
+     * 사용자 ID로 FCM 토큰 일괄 삭제 (회원 탈퇴용)
+     */
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/notification/NotificationSettingRepository.java
+++ b/src/main/java/com/waytoearth/repository/notification/NotificationSettingRepository.java
@@ -21,4 +21,9 @@ public interface NotificationSettingRepository extends JpaRepository<Notificatio
 
     /** 사용자에게 알림 설정이 있는지 확인 */
     boolean existsByUser(User user);
+
+    /**
+     * 사용자 ID로 알림 설정 삭제 (회원 탈퇴용)
+     */
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/waytoearth/repository/running/RunningRecordRepository.java
+++ b/src/main/java/com/waytoearth/repository/running/RunningRecordRepository.java
@@ -94,4 +94,7 @@ public interface RunningRecordRepository extends JpaRepository<RunningRecord, Lo
             @Param("user") User user,
             @Param("cursor") Long cursor,
             Pageable pageable);
+
+    // 사용자 ID로 러닝 기록 일괄 삭제 (회원 탈퇴용)
+    void deleteByUserId(Long userId);
 }


### PR DESCRIPTION
## 📝 Summary
  회원 탈퇴 API 구현 (사용자 데이터 완전 삭제 + 카카오 연동 해제)

  ## 🎯 Changes
  ### API
  - `DELETE /v1/users/me` - 회원 탈퇴 API 추가

  ### 주요 기능
  1. **카카오 연동 해제**
     - WayToEarth ↔️ 카카오 계정 연결 해제
     - 사용자의 카카오 "연결된 서비스 목록"에서 제거
     - 카카오 계정 자체는 유지됨 (카카오톡 등 계속 사용 가능)

  2. **연관 데이터 완전 삭제**
     - 피드 좋아요 (FeedLike)
     - 피드 (Feed)
     - 방명록 (Guestbook)
     - 크루 가입 신청 (CrewJoinRequest)
     - 크루 멤버십 (CrewMember)
     - 러닝 기록 (RunningRecord + RunningRoute cascade)
     - 여행 진행 내역 (UserJourneyProgress + Stamp cascade)
     - 사용자 엠블럼 (UserEmblem)
     - FCM 토큰 (FcmToken)
     - 알림 설정 (NotificationSetting)
     - S3 프로필 이미지
     - 사용자 계정 (User)

  3. **안전한 삭제 처리**
     - @Transactional로 원자성 보장 (전부 성공 or 전부 롤백)
     - 외래키 제약 순서 고려한 순차 삭제
     - 카카오/S3 삭제 실패 시에도 회원 탈퇴 계속 진행
     - 상세한 로깅으로 추적 가능

  ## 📁 Modified Files
  ### Controllers
  - `UserController.java` - 회원 탈퇴 API 엔드포인트 추가

  ### Services
  - `UserService.java` - 회원 탈퇴 비즈니스 로직 구현
  - `KakaoApiService.java` - 카카오 연동 해제 메서드 추가

  ### Repositories (deleteByUserId 메서드 추가)
  - `UserEmblemRepository.java`
  - `UserJourneyProgressRepository.java`
  - `RunningRecordRepository.java`
  - `CrewMemberRepository.java`
  - `FeedRepository.java`
  - `FeedLikeRepository.java`
  - `GuestbookRepository.java`
  - `CrewJoinRequestRepository.java`
  - `FcmTokenRepository.java`
  - `NotificationSettingRepository.java`

  ## 🔧 Technical Details
  ### API Specification
  DELETE /v1/users/me
  Authorization: Bearer {JWT_TOKEN}

  Response: 200 OK
  {
    "success": true,
    "message": "회원 탈퇴가 완료되었습니다.",
    "data": null
  }

  ### 실행 순서
  1. JWT 토큰에서 userId 추출
  2. 카카오 연동 해제 (실패 시 경고 로그)
  3. S3 프로필 이미지 삭제 (실패 시 경고 로그)
  4. DB 연관 데이터 삭제 (10개 테이블, 외래키 순서 고려)
  5. DB 사용자 삭제

  ### 재가입 시나리오
  - 카카오 연동이 해제되어 있어 재가입 시 다시 동의 필요
  - 완전히 새로운 계정으로 가입
  - 이전 데이터는 복구 불가능

  ## ✅ Test Checklist
  - [ ] 회원 탈퇴 API 호출 성공
  - [ ] DB에서 사용자 데이터 삭제 확인
  - [ ] DB에서 연관 데이터 모두 삭제 확인
  - [ ] 카카오 "연결된 서비스" 목록에서 제거 확인
  - [ ] S3 프로필 이미지 삭제 확인
  - [ ] 탈퇴 후 재로그인 시도 시 신규 회원으로 처리 확인
  - [ ] 재가입 시 카카오 동의 화면 표시 확인
  - [ ] 트랜잭션 롤백 테스트 (DB 삭제 중 에러 발생 시)

  ## 🚨 Breaking Changes
  없음

  ## 📌 Notes
  - 회원 탈퇴는 되돌릴 수 없는 작업입니다
  - 카카오 계정은 삭제되지 않으며, 연동만 해제됩니다
  - 프론트엔드에서는 탈퇴 성공 후 반드시 로컬 토큰을 삭제하고 로그인 페이지로 리다이렉트 해야 합니다
