### PR TITLE
feat: 회원 탈퇴 API 구현 및 이미지 URL CloudFront 적용 완료

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/crew/CrewMemberController.java
+++ b/src/main/java/com/waytoearth/controller/v1/crew/CrewMemberController.java
@@ -6,6 +6,7 @@ import com.waytoearth.dto.response.crew.CrewMemberResponse;
 import com.waytoearth.entity.crew.CrewMemberEntity;
 import com.waytoearth.security.AuthenticatedUser;
 import com.waytoearth.service.crew.CrewMemberService;
+import com.waytoearth.service.file.FileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -33,6 +34,7 @@ import java.util.stream.Collectors;
 public class CrewMemberController {
 
     private final CrewMemberService crewMemberService;
+    private final FileService fileService;
 
     @Operation(summary = "크루 멤버 목록 조회", description = "특정 크루의 멤버 목록을 페이징하여 조회합니다.")
     @ApiResponses({
@@ -49,7 +51,7 @@ public class CrewMemberController {
 
         Page<CrewMemberEntity> members = crewMemberService.getCrewMembers(crewId, pageable);
 
-        Page<CrewMemberResponse> response = members.map(CrewMemberResponse::from);
+        Page<CrewMemberResponse> response = members.map(member -> CrewMemberResponse.from(member, fileService));
 
         return ResponseEntity.ok(response);
     }
@@ -66,7 +68,7 @@ public class CrewMemberController {
         List<CrewMemberEntity> members = crewMemberService.getCrewMembersWithUser(crewId);
 
         List<CrewMemberResponse> response = members.stream()
-                .map(CrewMemberResponse::from)
+                .map(member -> CrewMemberResponse.from(member, fileService))
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(response);
@@ -134,7 +136,7 @@ public class CrewMemberController {
         CrewMemberEntity member = crewMemberService.changeMemberRole(
                 user, crewId, userId, request.getNewRole());
 
-        return ResponseEntity.ok(CrewMemberResponse.from(member));
+        return ResponseEntity.ok(CrewMemberResponse.from(member, fileService));
     }
 
     @Operation(summary = "내가 속한 크루 목록", description = "현재 사용자가 속한 모든 크루의 멤버십 정보를 조회합니다.")
@@ -149,7 +151,7 @@ public class CrewMemberController {
         List<CrewMemberEntity> memberships = crewMemberService.getUserCrewMemberships(user);
 
         List<CrewMemberResponse> response = memberships.stream()
-                .map(CrewMemberResponse::from)
+                .map(member -> CrewMemberResponse.from(member, fileService))
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(response);
@@ -167,7 +169,7 @@ public class CrewMemberController {
 
         CrewMemberEntity membership = crewMemberService.getCrewMembership(crewId, userId);
 
-        return ResponseEntity.ok(CrewMemberResponse.from(membership));
+        return ResponseEntity.ok(CrewMemberResponse.from(membership, fileService));
     }
 
     @Operation(summary = "크루 멤버 수 조회", description = "특정 크루의 활성 멤버 수를 조회합니다.")
@@ -218,7 +220,7 @@ public class CrewMemberController {
         List<CrewMemberEntity> members = crewMemberService.getRegularMembers(crewId);
 
         List<CrewMemberResponse> response = members.stream()
-                .map(CrewMemberResponse::from)
+                .map(member -> CrewMemberResponse.from(member, fileService))
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/waytoearth/dto/response/crew/CrewMemberResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/crew/CrewMemberResponse.java
@@ -1,6 +1,7 @@
 package com.waytoearth.dto.response.crew;
 
 import com.waytoearth.entity.crew.CrewMemberEntity;
+import com.waytoearth.service.file.FileService;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -38,6 +39,37 @@ public class CrewMemberResponse {
     @Schema(description = "크루장 여부", example = "false")
     private Boolean isOwner;
 
+    /**
+     * CloudFront URL을 사용하는 정적 팩토리 메서드
+     * @param member 크루 멤버 엔티티
+     * @param fileService CloudFront URL 생성을 위한 파일 서비스
+     * @return CrewMemberResponse
+     */
+    public static CrewMemberResponse from(CrewMemberEntity member, FileService fileService) {
+        // profileImageKey로 CloudFront URL 생성
+        String profileImageUrl = null;
+        if (member.getUser().getProfileImageKey() != null &&
+            !member.getUser().getProfileImageKey().isEmpty()) {
+            profileImageUrl = fileService.createPresignedGetUrl(member.getUser().getProfileImageKey());
+        }
+
+        return new CrewMemberResponse(
+                member.getId(),
+                member.getUser().getId(),
+                member.getUser().getNickname(),
+                profileImageUrl,
+                member.getRole().name(),
+                member.getJoinedAt(),
+                member.getIsActive(),
+                member.isOwner()
+        );
+    }
+
+    /**
+     * 하위 호환성을 위한 메서드 (deprecated)
+     * @deprecated FileService를 사용하는 from(CrewMemberEntity, FileService) 메서드를 사용하세요
+     */
+    @Deprecated
     public static CrewMemberResponse from(CrewMemberEntity member) {
         return new CrewMemberResponse(
                 member.getId(),

--- a/src/main/java/com/waytoearth/dto/response/feed/FeedResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/feed/FeedResponse.java
@@ -50,15 +50,17 @@ public record FeedResponse(
         Integer calories
 ) {
     public static FeedResponse from(Feed feed, boolean liked, FileService fileService) {
+        // 프로필 이미지 CloudFront URL 생성
         String profileImageKey = feed.getUser() != null ? feed.getUser().getProfileImageKey() : null;
         String profileImageUrl = (profileImageKey != null && !profileImageKey.isEmpty())
                 ? fileService.createPresignedGetUrl(profileImageKey)
                 : null;
 
+        // 피드 본문 이미지는 이미 CloudFront URL로 저장되어 있음
         return FeedResponse.builder()
                 .id(feed.getId())
                 .content(feed.getContent())
-                .imageUrl(feed.getImageUrl())
+                .imageUrl(feed.getImageUrl())  // 이미 CloudFront URL
                 .likeCount(feed.getLikeCount())
                 .liked(liked)   //  좋아요 여부 반영
                 .createdAt(feed.getCreatedAt().atZone(java.time.ZoneId.systemDefault()).toInstant())

--- a/src/main/java/com/waytoearth/repository/crew/CrewMemberRepository.java
+++ b/src/main/java/com/waytoearth/repository/crew/CrewMemberRepository.java
@@ -88,6 +88,7 @@ public interface CrewMemberRepository extends JpaRepository<CrewMemberEntity, Lo
 
     //멤버십 조회 (활성/비활성 무관)
     @Query("SELECT cm FROM CrewMemberEntity cm " +
+           "JOIN FETCH cm.user " +
            "WHERE cm.user.id = :userId AND cm.crew.id = :crewId")
     Optional<CrewMemberEntity> findMembership(@Param("userId") Long userId, @Param("crewId") Long crewId);
 


### PR DESCRIPTION

## 🔧 Changes

  ### 1. 회원 탈퇴 API 구현
  - **DELETE /v1/users/me** 엔드포인트 추가
  - 사용자 삭제 시 모든 연관 데이터 안전하게 cascade 삭제
  - 카카오 계정 연동 해제 기능 추가 (`KakaoApiService.unlinkKakaoAccount()`)
  - S3 프로필 이미지 자동 삭제

  **연관 데이터 삭제 순서:**
  1. FeedLike (피드 좋아요)
  2. Feed (피드)
  3. Guestbook (방명록)
  4. CrewJoinRequest (크루 가입 신청)
  5. CrewMember (크루 멤버십)
  6. RunningRecord (러닝 기록)
  7. UserJourneyProgress (여행 진행 내역)
  8. UserEmblem (사용자 엠블럼)
  9. FcmToken (FCM 토큰)
  10. NotificationSetting (알림 설정)
  11. User (최종 사용자 삭제)

  ### 2. LazyInitializationException 해결
  **문제:** `/v1/crews/{crewId}/members/{userId}` 엔드포인트에서 500 에러 발생
  - `CrewMemberRepository.findMembership()` 쿼리가 User 엔티티를 fetch하지 않아
  Hibernate Session 종료 후 Lazy Loading 실패

  **해결:** `JOIN FETCH cm.user` 추가로 User 엔티티를 즉시 로딩
  ```java
  @Query("SELECT cm FROM CrewMemberEntity cm " +
         "JOIN FETCH cm.user " +  // ← 추가
         "WHERE cm.user.id = :userId AND cm.crew.id = :crewId")
  Optional<CrewMemberEntity> findMembership(...);

  효과:
  - LazyInitializationException 해결 ✅
  - N+1 쿼리 문제 방지 ✅
  - 1개의 JOIN 쿼리로 모든 데이터 로딩 ✅

  3. 크루 멤버 프로필 이미지 CloudFront URL 적용

  문제: 크루 멤버 API에서 S3 presigned URL 대신 CloudFront URL을 반환해야 함

  해결:
  - CrewMemberResponse.from()에 FileService 파라미터 추가
  - profileImageKey를 CloudFront URL로 동적 변환
  - 다음 엔드포인트들에 적용:
    - GET /v1/crews/{crewId}/members (페이징)
    - GET /v1/crews/{crewId}/members/all (전체)
    - GET /v1/crews/{crewId}/members/{userId} (단일)
    - PATCH /v1/crews/{crewId}/members/{userId}/role (역할 변경)
    - GET /v1/crews/memberships/my (내 멤버십)
    - GET /v1/crews/{crewId}/members/regular (일반 멤버)

  4. 엠블럼 이미지 CloudFront URL 적용

  - EmblemService에 FileService 주입
  - toCloudFrontUrl() 헬퍼 메서드 추가
    - DB에 S3 키로 저장된 경우 → CloudFront URL로 변환
    - 이미 URL로 저장된 경우 → 그대로 반환
  - catalog(), detail() 메서드에 적용

  📝 Files Changed

  신규 추가

  - KakaoApiService.unlinkKakaoAccount() - 카카오 연동 해제

  수정

  - UserService.java - deleteUser() 메서드 추가
  - UserController.java - DELETE /v1/users/me 엔드포인트 추가
  - CrewMemberRepository.java - findMembership() 쿼리에 JOIN FETCH 추가
  - CrewMemberResponse.java - FileService 기반 CloudFront URL 생성
  - CrewMemberController.java - 6개 엔드포인트에 FileService 적용
  - EmblemService.java - CloudFront URL 변환 로직 추가
  - 10개 Repository - deleteByUserId() 메서드 추가
    - UserEmblemRepository
    - UserJourneyProgressRepository
    - RunningRecordRepository
    - CrewMemberRepository
    - FeedRepository
    - FeedLikeRepository
    - GuestbookRepository
    - CrewJoinRequestRepository
    - FcmTokenRepository
    - NotificationSettingRepository

  🧪 Test Cases

  - 회원 탈퇴 API 정상 작동
  - 연관 데이터 모두 삭제 확인
  - 카카오 연동 해제 확인
  - S3 프로필 이미지 삭제 확인
  - 크루 멤버 조회 시 CloudFront URL 반환 확인
  - LazyInitializationException 해결 확인
  - 엠블럼 이미지 CloudFront URL 반환 확인

  🔗 Related Issues

  - 회원 탈퇴 기능 구현
  - 크루 멤버 API 이미지 URL 개선
  - JPA Lazy Loading 문제 해결
  - 엠블럼 이미지 CDN 적용

  📸 Screenshots

  N/A (API 기능 개선)

  ⚠️ Breaking Changes

  None

  📌 Notes

  - 카카오 연동 해제 시 Admin Key 사용 (KakaoAK prefix)
  - 회원 탈퇴 시 카카오 계정 자체는 삭제되지 않음 (연동만 해제)
  - JOIN FETCH 사용으로 쿼리 최적화 및 N+1 문제 방지
  - CloudFront URL은 타임스탬프 쿼리 파라미터로 캐시 버스팅 적용

