### PR TITLE
Crew owner 회원 탈퇴 예외

### DIFF
--- a/src/main/java/com/waytoearth/entity/crew/CrewChatEntity.java
+++ b/src/main/java/com/waytoearth/entity/crew/CrewChatEntity.java
@@ -16,6 +16,7 @@ import java.util.List;
            @Index(name = "idx_crew_chat_crew_sent_at", columnList = "crew_id, sent_at"),
            @Index(name = "idx_crew_chat_crew_deleted", columnList = "crew_id, is_deleted"),
            @Index(name = "idx_crew_chat_sender", columnList = "sender_id")
+
        })
 @Getter
 @Setter

--- a/src/main/java/com/waytoearth/exception/CrewOwnerCannotDeleteAccountException.java
+++ b/src/main/java/com/waytoearth/exception/CrewOwnerCannotDeleteAccountException.java
@@ -1,0 +1,11 @@
+package com.waytoearth.exception;
+
+/**
+ * 크루장이 회원 탈퇴를 시도할 때 발생하는 예외
+ * 크루장은 먼저 크루장 권한을 이양하거나 크루를 삭제해야 함
+ */
+public class CrewOwnerCannotDeleteAccountException extends RuntimeException {
+    public CrewOwnerCannotDeleteAccountException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/waytoearth/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/waytoearth/exception/GlobalExceptionHandler.java
@@ -207,6 +207,22 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
+    @ExceptionHandler(CrewOwnerCannotDeleteAccountException.class)
+    public ResponseEntity<ErrorResponse> handleCrewOwnerCannotDeleteAccountException(CrewOwnerCannotDeleteAccountException e) {
+        log.warn("크루장 회원 탈퇴 차단: {}", e.getMessage());
+
+        ErrorResponse response = ErrorResponse.builder()
+                .success(false)
+                .error(ErrorDetail.builder()
+                        .code("CREW_OWNER_CANNOT_DELETE_ACCOUNT")
+                        .message(e.getMessage())
+                        .build())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(Exception e) {
         log.error("예상치 못한 서버 오류", e);

--- a/src/main/java/com/waytoearth/service/user/UserService.java
+++ b/src/main/java/com/waytoearth/service/user/UserService.java
@@ -25,6 +25,9 @@ import com.waytoearth.repository.crew.CrewChatNotificationSettingRepository;
 import com.waytoearth.repository.crew.CrewChatRepository;
 import com.waytoearth.service.auth.KakaoApiService;
 import com.waytoearth.repository.crew.CrewStatisticsRepository;
+import com.waytoearth.repository.crew.CrewRepository;
+import com.waytoearth.entity.crew.CrewEntity;
+import com.waytoearth.exception.CrewOwnerCannotDeleteAccountException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -61,6 +64,7 @@ public class UserService {
     private final CrewChatNotificationSettingRepository crewChatNotificationSettingRepository;
     private final CrewChatRepository crewChatRepository;
     private final CrewStatisticsRepository crewStatisticsRepository;
+    private final CrewRepository crewRepository;
 
     // 카카오 연동 해제를 위한 서비스
     private final KakaoApiService kakaoApiService;

--- a/src/main/java/com/waytoearth/service/user/UserService.java
+++ b/src/main/java/com/waytoearth/service/user/UserService.java
@@ -303,19 +303,19 @@ public class UserService {
         feedLikeRepository.deleteByUserId(userId);
         log.debug("[UserService] 피드 좋아요 삭제 완료");
 
-        // 4-2. 피드 삭제 (Feed -> RunningRecord 참조)
+        // 5-2. 피드 삭제 (Feed -> RunningRecord 참조)
         feedRepository.deleteByUserId(userId);
         log.debug("[UserService] 피드 삭제 완료");
 
-        // 4-3. 방명록 삭제
+        // 5-3. 방명록 삭제
         guestbookRepository.deleteByUserId(userId);
         log.debug("[UserService] 방명록 삭제 완료");
 
-        // 4-4. 크루 가입 신청 삭제
+        // 5-4. 크루 가입 신청 삭제
         crewJoinRequestRepository.deleteByUserId(userId);
         log.debug("[UserService] 크루 가입 신청 삭제 완료");
 
-        // 4-5. 크루 멤버십 삭제
+        // 5-5. 크루 멤버십 삭제 (크루장이 아닌 일반 멤버십만 존재)
         var memberships = crewMemberRepository.findByUserIdWithCrew(userId);
         var affectedCrewIds = memberships.stream().map(m -> m.getCrew().getId()).distinct().toList();
         crewMemberRepository.deleteByUserId(userId);
@@ -324,40 +324,40 @@ public class UserService {
         }
         log.debug("[UserService] 크루 멤버십 삭제 완료");
 
-        // 4-6. 러닝 기록 삭제 (RunningRoute는 cascade로 자동 삭제됨)
+        // 5-6. 러닝 기록 삭제 (RunningRoute는 cascade로 자동 삭제됨)
         runningRecordRepository.deleteByUserId(userId);
         log.debug("[UserService] 러닝 기록 삭제 완료");
 
-        // 4-7. 여행 진행 내역 삭제 (StampEntity는 cascade로 자동 삭제됨)
+        // 5-7. 여행 진행 내역 삭제 (StampEntity는 cascade로 자동 삭제됨)
         userJourneyProgressRepository.deleteByUserId(userId);
         log.debug("[UserService] 여행 진행 내역 삭제 완료");
 
-        // 4-8. 사용자 엠블럼 삭제
+        // 5-8. 사용자 엠블럼 삭제
         userEmblemRepository.deleteByUserId(userId);
         log.debug("[UserService] 사용자 엠블럼 삭제 완료");
 
-        // 4-9. FCM 토큰 삭제
+        // 5-9. FCM 토큰 삭제
         fcmTokenRepository.deleteByUserId(userId);
         log.debug("[UserService] FCM 토큰 삭제 완료");
 
-        // 4-10. 알림 설정 삭제 (글로벌)
+        // 5-10. 알림 설정 삭제 (글로벌)
         notificationSettingRepository.deleteByUserId(userId);
         log.debug("[UserService] 알림 설정 삭제 완료");
 
-        // 4-11. 크루 채팅 읽음 상태 삭제
+        // 5-11. 크루 채팅 읽음 상태 삭제
         crewChatReadStatusRepository.deleteByReaderId(userId);
         log.debug("[UserService] 크루 채팅 읽음 상태 삭제 완료");
 
-        // 4-12. 크루 채팅 알림 설정 삭제
+        // 5-12. 크루 채팅 알림 설정 삭제
         crewChatNotificationSettingRepository.deleteByUserId(userId);
         log.debug("[UserService] 크루 채팅 알림 설정 삭제 완료");
 
-        // 4-13. 사용자가 보낸 채팅은 보존: 발신자를 '탈퇴한 사용자'로 치환
+        // 5-13. 사용자가 보낸 채팅은 보존: 발신자를 '탈퇴한 사용자'로 치환
         User deletedSentinel = getOrCreateDeletedUserSentinel();
         int reassigned = crewChatRepository.reassignSenderToDeleted(userId, deletedSentinel);
         log.debug("[UserService] 보낸 채팅 발신자 치환 완료 - reassigned: {}", reassigned);
 
-        // 5. 최종적으로 사용자 삭제
+        // 6. 최종적으로 사용자 삭제
         userRepository.delete(user);
         log.info("[UserService] 회원 탈퇴 완료 - userId: {}, kakaoId: {}", userId, user.getKakaoId());
     }

--- a/src/main/java/com/waytoearth/service/user/UserService.java
+++ b/src/main/java/com/waytoearth/service/user/UserService.java
@@ -276,7 +276,7 @@ public class UserService {
             throw new CrewOwnerCannotDeleteAccountException(message);
         }
 
-        // 2. 카카오 연동 해제
+        // 3. 카카오 연동 해제
         try {
             kakaoApiService.unlinkKakaoAccount(user.getKakaoId());
             log.info("[UserService] 카카오 연동 해제 완료 - kakaoId: {}", user.getKakaoId());
@@ -285,7 +285,7 @@ public class UserService {
                      user.getKakaoId(), e.getMessage());
         }
 
-        // 3. 프로필 이미지가 있다면 S3에서 삭제
+        // 4. 프로필 이미지가 있다면 S3에서 삭제
         if (user.getProfileImageKey() != null && !user.getProfileImageKey().isEmpty()) {
             try {
                 fileService.deleteObject(user.getProfileImageKey());
@@ -296,10 +296,10 @@ public class UserService {
             }
         }
 
-        // 4. 연관 데이터 삭제 (외래키 제약 순서 고려)
+        // 5. 연관 데이터 삭제 (외래키 제약 순서 고려)
         log.info("[UserService] 연관 데이터 삭제 시작 - userId: {}", userId);
 
-        // 4-1. 피드 좋아요 삭제 (FeedLike -> Feed 참조)
+        // 5-1. 피드 좋아요 삭제 (FeedLike -> Feed 참조)
         feedLikeRepository.deleteByUserId(userId);
         log.debug("[UserService] 피드 좋아요 삭제 완료");
 


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


> 이번 PR에서 작업한 내용을 간략히 설명해주세요

 변경 사항

  1. 예외 클래스 생성
  - CrewOwnerCannotDeleteAccountException.java (새 파일)
    - 크루장이 회원 탈퇴를 시도할 때 발생하는 예외

  2. UserService.java 수정
  - CrewRepository 주입 추가 (line 67)
  - 크루장 검증 로직 추가 (line 257-277):
  // 크루장 여부 확인
  List<CrewEntity> ownedCrews = crewRepository.findByOwnerAndIsActiveTrue(user);
  if (!ownedCrews.isEmpty()) {
      // 소유 중인 크루가 있으면 탈퇴 차단
      throw new CrewOwnerCannotDeleteAccountException(message);
  }
    - 활성화된 크루 중 사용자가 owner인 크루 조회
    - 소유 중인 크루가 있으면 예외 발생 (최대 3개 크루 이름 표시)
    - 소유 중인 크루가 없으면 정상 진행

  3. GlobalExceptionHandler.java 수정
  - 새 예외 핸들러 추가 (line 210-224):
    - HTTP 400 (BAD_REQUEST) 응답
    - 에러 코드: CREW_OWNER_CANNOT_DELETE_ACCOUNT
    - 상세한 에러 메시지 반환 (소유 크루 목록 포함)

  ---
  동작 방식

  회원 탈퇴 시나리오

  일반 멤버:
  회원 탈퇴 요청 → 크루장 검증 통과 → 정상 탈퇴 진행 

  크루장 (크루 소유):
  회원 탈퇴 요청 → 크루장 검증 실패 → 예외 발생 

  에러 응답:
  {
    "success": false,
    "error": {
      "code": "CREW_OWNER_CANNOT_DELETE_ACCOUNT",
      "message": "크루장은 회원 탈퇴할 수 없습니다. 먼저 크루장 권한을 이양하거나 크루를 삭제해주세요. 소유 중인 크루: 크루A, 크루B (총      
  2개)"
    },
    "timestamp": "2025-10-24T..."
  }

  크루장이 탈퇴하려면:
  1. 소유한 모든 크루의 권한을 다른 멤버에게 이양하거나
  2. 소유한 모든 크루를 삭제해야 함



### 테스트 결과 or 스크린샷 (선택)
> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요