### PR TITLE
feat: Journey 진행 조회 시 함께 뛰는 러너 수 표시 기능 구현

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/journey/JourneyProgressController.java
+++ b/src/main/java/com/waytoearth/controller/v1/journey/JourneyProgressController.java
@@ -107,6 +107,7 @@ public class JourneyProgressController {
             - 다음 랜드마크 정보
             - 수집한 스탬프 수
             - 총 랜드마크 수
+            - 함께 뛰는 러너 수 (진행 중 + 완료)
             """,
         tags = {"Journey Progress API"}
     )
@@ -154,6 +155,7 @@ public class JourneyProgressController {
             - 다음 랜드마크 정보
             - 수집한 스탬프 수
             - 총 랜드마크 수
+            - 함께 뛰는 러너 수 (진행 중 + 완료)
 
             **사용 예시:**
             - 여정 리스트에서 특정 여정 선택 시

--- a/src/main/java/com/waytoearth/dto/response/journey/JourneyProgressResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/journey/JourneyProgressResponse.java
@@ -33,7 +33,10 @@ public record JourneyProgressResponse(
     Integer collectedStamps,
 
     @Schema(description = "총 랜드마크 수", example = "15")
-    Integer totalLandmarks
+    Integer totalLandmarks,
+
+    @Schema(description = "함께 뛰는 러너 수 (진행 중 + 완료)", example = "42")
+    Long runningTogether
 ) {
     public static JourneyProgressResponse from(
             UserJourneyProgressEntity progress,

--- a/src/main/java/com/waytoearth/dto/response/journey/JourneyProgressResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/journey/JourneyProgressResponse.java
@@ -42,7 +42,8 @@ public record JourneyProgressResponse(
             UserJourneyProgressEntity progress,
             LandmarkSummaryResponse nextLandmark,
             Integer collectedStamps,
-            Integer totalLandmarks
+            Integer totalLandmarks,
+            Long runningTogether
     ) {
         return new JourneyProgressResponse(
             progress.getId(),
@@ -54,7 +55,8 @@ public record JourneyProgressResponse(
             progress.getStatus().name(),
             nextLandmark,
             collectedStamps,
-            totalLandmarks
+            totalLandmarks,
+            runningTogether
         );
     }
 }

--- a/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepository.java
+++ b/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepository.java
@@ -83,6 +83,13 @@ public interface UserJourneyProgressRepository extends JpaRepository<UserJourney
     Long countCompletedRunnersByJourneyId(@Param("journeyId") Long journeyId);
 
     /**
+     * 특정 여정을 진행 중이거나 완료한 모든 러너 수 (함께 뛰는 사람)
+     * ACTIVE 또는 COMPLETED 상태인 고유 사용자 수 반환
+     */
+    @Query("SELECT COUNT(DISTINCT ujp.user.id) FROM UserJourneyProgressEntity ujp WHERE ujp.journey.id = :journeyId AND ujp.status IN ('ACTIVE', 'COMPLETED')")
+    Long countActiveOrCompletedRunnersByJourneyId(@Param("journeyId") Long journeyId);
+
+    /**
      * 사용자 ID로 여행 진행 내역 일괄 삭제 (회원 탈퇴용)
      */
     void deleteByUserId(Long userId);

--- a/src/main/java/com/waytoearth/service/journey/JourneyServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/journey/JourneyServiceImpl.java
@@ -256,11 +256,15 @@ public class JourneyServiceImpl implements JourneyService {
         // 총 랜드마크 수
         Long totalLandmarks = landmarkRepository.countLandmarksByJourneyId(progress.getJourney().getId());
 
+        // 함께 뛰는 러너 수 (진행 중 + 완료)
+        Long runningTogether = progressRepository.countActiveOrCompletedRunnersByJourneyId(progress.getJourney().getId());
+
         return JourneyProgressResponse.from(
                 progress,
                 nextLandmark,
                 collectedStamps.intValue(),
-                totalLandmarks.intValue()
+                totalLandmarks.intValue(),
+                runningTogether
         );
     }
 


### PR DESCRIPTION

  ## Summary
  - Journey 진행 조회 API에서 "함께 뛰는 러너 수" 필드 추가
  - ACTIVE 또는 COMPLETED 상태인 고유 사용자 수를 반환하여 같은 여정을 함께 뛰는 러너 수를 정확히 표시
  - 기존에 0명으로 표시되던 문제 해결

  ## Changes
  - **Repository**: `countActiveOrCompletedRunnersByJourneyId()` 쿼리 메서드 추가
    - JPQL로 ACTIVE, COMPLETED 상태인 고유 사용자 수 조회
    - DISTINCT 사용으로 중복 카운트 방지
  - **DTO**: `JourneyProgressResponse`에 `runningTogether` 필드 추가
    - `from()` 정적 팩토리 메서드 시그니처 업데이트
  - **Service**: `buildProgressResponse()`에 러너 수 조회 로직 추가
    - 모든 Journey 진행 조회 API에 자동 적용
  - **Controller**: Swagger API 문서에 새 필드 설명 추가

  ## Affected APIs
  다음 5개 엔드포인트에서 `runningTogether` 필드가 응답에 포함됩니다:
  - `GET /v1/journey-progress/{progressId}` - 진행률 조회
  - `PUT /v1/journey-progress/{progressId}` - 진행률 업데이트
  - `PUT /v1/journey-progress/session/{sessionId}` - 세션 기반 진행률 업데이트
  - `GET /v1/journey-progress/user/{userId}` - 사용자 여정 목록
  - `GET /v1/journey-progress/user/{userId}/journey/{journeyId}` - 특정 여정 진행률

  ## Test plan
  - [x] 빌드 성공 확인
  - [ ] Swagger UI에서 API 응답에 `runningTogether` 필드 포함 확인
  - [ ] 여정을 시작한 사용자가 카운트에 포함되는지 확인 (ACTIVE)
  - [ ] 여정을 완료한 사용자가 카운트에 포함되는지 확인 (COMPLETED)
  - [ ] 동일 사용자가 중복 카운트되지 않는지 확인
