### PR TITLE
openjdk 지원 중단으로 인한 dockerfile temurin으로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21
+FROM eclipse-temurin:21-jre
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
openjdk 21 중단으로 eclipse-temurin:21-jre으로 변경