### PR TITLE
 feat: 여정 목록 조회 N+1 쿼리 문제 최적화

### DIFF
--- a/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepository.java
+++ b/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface UserJourneyProgressRepository extends JpaRepository<UserJourneyProgressEntity, Long> {
+public interface UserJourneyProgressRepository extends JpaRepository<UserJourneyProgressEntity, Long>, UserJourneyProgressRepositoryCustom {
 
     /**
      * 진행 ID로 조회 (Journey 정보 포함)

--- a/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepositoryCustom.java
+++ b/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.waytoearth.repository.journey;
+
+import com.waytoearth.dto.response.journey.JourneyProgressResponse;
+import java.util.List;
+
+public interface UserJourneyProgressRepositoryCustom {
+
+    /**
+     * 사용자 ID로 모든 여정 진행 상태를 조회 (N+1 문제 해결)
+     * - 한 번의 쿼리로 각 여정 진행에 필요한 모든 정보를 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return JourneyProgressResponse 리스트
+     */
+    List<JourneyProgressResponse> findProgressResponsesByUserId(Long userId);
+}

--- a/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepositoryImpl.java
+++ b/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepositoryImpl.java
@@ -1,0 +1,167 @@
+package com.waytoearth.repository.journey;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.waytoearth.dto.response.journey.JourneyProgressResponse;
+import com.waytoearth.dto.response.journey.LandmarkSummaryResponse;
+import com.waytoearth.entity.enums.JourneyProgressStatus;
+import com.waytoearth.entity.journey.QLandmarkEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.waytoearth.entity.journey.QJourneyEntity.journeyEntity;
+import static com.waytoearth.entity.journey.QLandmarkEntity.landmarkEntity;
+import static com.waytoearth.entity.journey.QStampEntity.stampEntity;
+import static com.waytoearth.entity.journey.QUserJourneyProgressEntity.userJourneyProgressEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class UserJourneyProgressRepositoryImpl implements UserJourneyProgressRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final LandmarkRepository landmarkRepository;
+
+    private static class JourneyProgressDto {
+        Long progressId;
+        Long journeyId;
+        String journeyTitle;
+        Double totalDistanceKm;
+        Double currentDistanceKm;
+        Double progressPercent;
+        JourneyProgressStatus status;
+        Long nextLandmarkId; // 다음 랜드마크 ID만 조회
+
+        public JourneyProgressDto(Long progressId, Long journeyId, String journeyTitle, Double totalDistanceKm,
+                                  Double currentDistanceKm, Double progressPercent, JourneyProgressStatus status, Long nextLandmarkId) {
+            this.progressId = progressId;
+            this.journeyId = journeyId;
+            this.journeyTitle = journeyTitle;
+            this.totalDistanceKm = totalDistanceKm;
+            this.currentDistanceKm = currentDistanceKm;
+            this.progressPercent = progressPercent;
+            this.status = status;
+            this.nextLandmarkId = nextLandmarkId;
+        }
+    }
+
+    @Override
+    public List<JourneyProgressResponse> findProgressResponsesByUserId(Long userId) {
+        // 1. 여정 진행 정보와 각종 통계, 다음 랜드마크 ID를 한 번에 조회
+        List<JourneyProgressDto> progressDtos = queryFactory
+                .select(Projections.constructor(JourneyProgressDto.class,
+                        userJourneyProgressEntity.id,
+                        journeyEntity.id,
+                        journeyEntity.title,
+                        journeyEntity.totalDistanceKm,
+                        userJourneyProgressEntity.currentDistanceKm,
+                        userJourneyProgressEntity.progressPercent,
+                        userJourneyProgressEntity.status,
+                        // 다음 랜드마크 ID 서브쿼리
+                        JPAExpressions.select(landmarkEntity.id.min())
+                                .from(landmarkEntity)
+                                .where(landmarkEntity.journey.id.eq(journeyEntity.id)
+                                        .and(landmarkEntity.distanceFromStart.gt(userJourneyProgressEntity.currentDistanceKm)))
+                ))
+                .from(userJourneyProgressEntity)
+                .join(userJourneyProgressEntity.journey, journeyEntity)
+                .where(userJourneyProgressEntity.user.id.eq(userId))
+                .orderBy(userJourneyProgressEntity.createdAt.desc())
+                .fetch();
+
+        if (progressDtos.isEmpty()) {
+            return List.of();
+        }
+
+        // 2. 다음 랜드마크 정보를 한 번의 쿼리로 조회
+        List<Long> nextLandmarkIds = progressDtos.stream()
+                .map(dto -> dto.nextLandmarkId)
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+
+        Map<Long, LandmarkSummaryResponse> nextLandmarkMap = landmarkRepository.findAllById(nextLandmarkIds).stream()
+                .map(LandmarkSummaryResponse::from)
+                .collect(Collectors.toMap(LandmarkSummaryResponse::id, Function.identity()));
+
+        // 3. 각 여정별 추가 정보(스탬프, 총 랜드마크, 함께하는 러너)를 각각의 쿼리로 조회
+        // 이 부분도 최적화가 가능하지만, 우선 N+1의 주범인 루프 내 쿼리를 제거
+        Map<Long, Long> collectedStampsMap = getCollectedStampsCount(progressDtos);
+        Map<Long, Long> totalLandmarksMap = getTotalLandmarksCount(progressDtos);
+        Map<Long, Long> runningTogetherMap = getRunningTogetherCount(progressDtos);
+
+
+        // 4. DTO 조합
+        return progressDtos.stream()
+                .map(dto -> new JourneyProgressResponse(
+                        dto.progressId,
+                        dto.journeyId,
+                        dto.journeyTitle,
+                        dto.totalDistanceKm,
+                        dto.currentDistanceKm,
+                        dto.progressPercent,
+                        dto.status.name(),
+                        dto.nextLandmarkId != null ? nextLandmarkMap.get(dto.nextLandmarkId) : null,
+                        collectedStampsMap.getOrDefault(dto.progressId, 0L).intValue(),
+                        totalLandmarksMap.getOrDefault(dto.journeyId, 0L).intValue(),
+                        runningTogetherMap.getOrDefault(dto.journeyId, 0L)
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private Map<Long, Long> getCollectedStampsCount(List<JourneyProgressDto> progressDtos) {
+        List<Long> progressIds = progressDtos.stream().map(dto -> dto.progressId).toList();
+        return queryFactory
+                .select(stampEntity.progress.id, stampEntity.count())
+                .from(stampEntity)
+                .where(stampEntity.progress.id.in(progressIds))
+                .groupBy(stampEntity.progress.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(stampEntity.progress.id),
+                        tuple -> tuple.get(stampEntity.count())
+                ));
+    }
+
+    private Map<Long, Long> getTotalLandmarksCount(List<JourneyProgressDto> progressDtos) {
+        List<Long> journeyIds = progressDtos.stream().map(dto -> dto.journeyId).distinct().toList();
+        return queryFactory
+                .select(landmarkEntity.journey.id, landmarkEntity.count())
+                .from(landmarkEntity)
+                .where(landmarkEntity.journey.id.in(journeyIds))
+                .groupBy(landmarkEntity.journey.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(landmarkEntity.journey.id),
+                        tuple -> tuple.get(landmarkEntity.count())
+                ));
+    }
+
+    private Map<Long, Long> getRunningTogetherCount(List<JourneyProgressDto> progressDtos) {
+        QLandmarkEntity ujpSub = new QLandmarkEntity("ujpSub");
+        List<Long> journeyIds = progressDtos.stream().map(dto -> dto.journeyId).distinct().toList();
+        
+        // QUserJourneyProgressEntity를 별칭으로 사용해야 함
+        com.waytoearth.entity.journey.QUserJourneyProgressEntity subUjp = new com.waytoearth.entity.journey.QUserJourneyProgressEntity("subUjp");
+
+        return queryFactory
+                .select(subUjp.journey.id, subUjp.user.id.countDistinct())
+                .from(subUjp)
+                .where(subUjp.journey.id.in(journeyIds)
+                        .and(subUjp.status.in(JourneyProgressStatus.ACTIVE, JourneyProgressStatus.COMPLETED)))
+                .groupBy(subUjp.journey.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(subUjp.journey.id),
+                        tuple -> tuple.get(subUjp.user.id.countDistinct())
+                ));
+    }
+}

--- a/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepositoryImpl.java
+++ b/src/main/java/com/waytoearth/repository/journey/UserJourneyProgressRepositoryImpl.java
@@ -117,14 +117,14 @@ public class UserJourneyProgressRepositoryImpl implements UserJourneyProgressRep
     private Map<Long, Long> getCollectedStampsCount(List<JourneyProgressDto> progressDtos) {
         List<Long> progressIds = progressDtos.stream().map(dto -> dto.progressId).toList();
         return queryFactory
-                .select(stampEntity.progress.id, stampEntity.count())
+                .select(stampEntity.userJourneyProgress.id, stampEntity.count())
                 .from(stampEntity)
-                .where(stampEntity.progress.id.in(progressIds))
-                .groupBy(stampEntity.progress.id)
+                .where(stampEntity.userJourneyProgress.id.in(progressIds))
+                .groupBy(stampEntity.userJourneyProgress.id)
                 .fetch()
                 .stream()
                 .collect(Collectors.toMap(
-                        tuple -> tuple.get(stampEntity.progress.id),
+                        tuple -> tuple.get(stampEntity.userJourneyProgress.id),
                         tuple -> tuple.get(stampEntity.count())
                 ));
     }

--- a/src/main/java/com/waytoearth/service/journey/JourneyServiceImpl.java
+++ b/src/main/java/com/waytoearth/service/journey/JourneyServiceImpl.java
@@ -188,11 +188,7 @@ public class JourneyServiceImpl implements JourneyService {
 
     @Override
     public List<JourneyProgressResponse> getUserJourneys(Long userId) {
-        List<UserJourneyProgressEntity> progressList = progressRepository.findByUserIdWithJourney(userId);
-
-        return progressList.stream()
-                .map(this::buildProgressResponse)
-                .toList();
+        return progressRepository.findProgressResponsesByUserId(userId);
     }
 
     @Override


### PR DESCRIPTION

  주요 변경 내용

  문제점

   - JourneyServiceImpl의 getUserJourneys 메서드는 사용자의 전체 여정 진행 목록을 조회할 때, 각 여정 항목에 대한 추가 정보를 얻기 위해 루프 내에서 여러 번의
     쿼리(스탬프 수, 랜드마크 수 등)를 실행했습니다.
   - 이로 인해 사용자가 참여한 여정이 많아질수록 API 응답 시간이 급격히 느려지는 N+1 쿼리 문제가 발생했습니다.

  해결 방안

   - QueryDSL을 사용하여 UserJourneyProgressRepository에 커스텀 구현을 추가하여, 관련된 모든 정보를 상수 개수의 쿼리로 조회하도록 최적화했습니다.
   - 기존의 buildProgressResponse 메서드를 순회 호출하는 대신, 새로 작성한 findProgressResponsesByUserId 메서드를 사용하여 필요한 모든 데이터를 한 번에 효율적으로
     가져옵니다.

  세부 구현

   1. `UserJourneyProgressRepositoryCustom` 인터페이스 추가: QueryDSL 커스텀 메서드를 위한 인터페이스를 정의했습니다.
   2. `UserJourneyProgressRepositoryImpl` 구현체 추가:
       - 1차 쿼리에서 여정 진행 정보, 통계, 다음 랜드마크 ID 등을 조회합니다.
       - 추가 쿼리를 통해 다음 랜드마크의 상세 정보, 스탬프 수, 총 랜드마크 수, 함께하는 러너 수 등의 정보를 일괄적으로 조회합니다.
       - 조회된 데이터를 조합하여 JourneyProgressResponse DTO 리스트를 생성합니다.
   3. `UserJourneyProgressRepository` 수정: UserJourneyProgressRepositoryCustom 인터페이스를 상속하도록 변경했습니다.
   4. `JourneyServiceImpl` 리팩토링: getUserJourneys 메서드가 새로운 최적화된 쿼리 메서드를 호출하도록 수정했습니다.

