### PR TITLE
  feat: 온보딩에 키/몸무게 입력 추가 및 칼로리 계산 개인화

### DIFF
--- a/src/main/java/com/waytoearth/dto/request/auth/OnboardingRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/auth/OnboardingRequest.java
@@ -34,6 +34,18 @@ public class OnboardingRequest {
     @NotNull(message = "성별은 필수입니다")
     private Gender gender;
 
+    @Schema(description = "키(cm)", example = "175", required = true)
+    @NotNull(message = "키는 필수입니다")
+    @Min(value = 100, message = "키는 100cm 이상이어야 합니다")
+    @Max(value = 250, message = "키는 250cm 이하여야 합니다")
+    private Integer height;
+
+    @Schema(description = "몸무게(kg)", example = "70", required = true)
+    @NotNull(message = "몸무게는 필수입니다")
+    @Min(value = 30, message = "몸무게는 30kg 이상이어야 합니다")
+    @Max(value = 200, message = "몸무게는 200kg 이하여야 합니다")
+    private Integer weight;
+
     @Schema(description = "주간 목표 거리(km)", example = "15.5", required = true)
     @NotNull(message = "주간 목표 거리는 필수입니다")
     @DecimalMin(value = "0.1", message = "주간 목표 거리는 0.1km 이상이어야 합니다")

--- a/src/main/java/com/waytoearth/dto/response/user/UserInfoResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/user/UserInfoResponse.java
@@ -33,6 +33,12 @@ public class UserInfoResponse {
     @Schema(description = "성별", example = "남성")
     private String gender;
 
+    @Schema(description = "키(cm)", example = "175")
+    private Integer height;
+
+    @Schema(description = "몸무게(kg)", example = "70")
+    private Integer weight;
+
     @Schema(description = "주간 목표 거리(km)", example = "15.5")
     private BigDecimal weeklyGoalDistance;
 
@@ -54,15 +60,17 @@ public class UserInfoResponse {
     public UserInfoResponse() { }
 
     public UserInfoResponse(Long id, String nickname, String profileImageUrl, String residence,
-                            String ageGroup, String gender, BigDecimal weeklyGoalDistance,
-                            BigDecimal totalDistance, Integer totalRunningCount, Instant createdAt,
-                            String profileImageKey, String role) {
+                            String ageGroup, String gender, Integer height, Integer weight,
+                            BigDecimal weeklyGoalDistance, BigDecimal totalDistance, Integer totalRunningCount,
+                            Instant createdAt, String profileImageKey, String role) {
         this.id = id;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
         this.residence = residence;
         this.ageGroup = ageGroup;
         this.gender = gender;
+        this.height = height;
+        this.weight = weight;
         this.weeklyGoalDistance = weeklyGoalDistance;
         this.totalDistance = totalDistance;
         this.totalRunningCount = totalRunningCount;

--- a/src/main/java/com/waytoearth/entity/user/User.java
+++ b/src/main/java/com/waytoearth/entity/user/User.java
@@ -41,6 +41,12 @@ public class User extends BaseTimeEntity {
     @Column(name = "gender")
     private Gender gender;
 
+    @Column(name = "height")
+    private Integer height;
+
+    @Column(name = "weight")
+    private Integer weight;
+
     @Setter
     @Column(name = "weekly_goal_distance", precision = 5, scale = 2)
     private BigDecimal weeklyGoalDistance;
@@ -79,11 +85,14 @@ public class User extends BaseTimeEntity {
 
     // 온보딩 완료 메서드
     public void completeOnboarding(String nickname, String residence, AgeGroup ageGroup,
-                                   Gender gender, BigDecimal weeklyGoalDistance, String profileImageKey) {
+                                   Gender gender, Integer height, Integer weight,
+                                   BigDecimal weeklyGoalDistance, String profileImageKey) {
         this.nickname = nickname;
         this.residence = residence;
         this.ageGroup = ageGroup;
         this.gender = gender;
+        this.height = height;
+        this.weight = weight;
         this.weeklyGoalDistance = weeklyGoalDistance;
         this.profileImageKey = profileImageKey;
         this.isOnboardingCompleted = true;

--- a/src/main/java/com/waytoearth/service/user/UserService.java
+++ b/src/main/java/com/waytoearth/service/user/UserService.java
@@ -117,6 +117,8 @@ public class UserService {
                 request.getResidence(),
                 request.getAge_group(),
                 request.getGender(),
+                request.getHeight(),
+                request.getWeight(),
                 request.getWeekly_goal_distance(),
                 request.getProfileImageKey()
         );

--- a/src/main/java/com/waytoearth/service/user/UserService.java
+++ b/src/main/java/com/waytoearth/service/user/UserService.java
@@ -167,6 +167,8 @@ public class UserService {
                 u.getResidence(),
                 ageGroup,
                 gender,
+                u.getHeight(),
+                u.getWeight(),
                 u.getWeeklyGoalDistance(),
                 u.getTotalDistance(),
                 u.getTotalRunningCount(),

--- a/src/main/java/com/waytoearth/util/CalorieCalculator.java
+++ b/src/main/java/com/waytoearth/util/CalorieCalculator.java
@@ -1,0 +1,156 @@
+package com.waytoearth.util;
+
+/**
+ * 칼로리 계산 유틸리티 (METs 기반)
+ *
+ * <p><strong>⚠️ 프론트엔드/워치 개발자 필독:</strong></p>
+ * <p>이 클래스에 정의된 계산 공식을 <strong>동일하게</strong> 프론트엔드와 워치에서 구현하세요.</p>
+ * <p>계산 로직의 일관성을 유지하기 위해 아래 공식을 그대로 사용해주세요.</p>
+ *
+ * <h3>📐 칼로리 계산 공식 (METs 방식)</h3>
+ * <pre>
+ * 칼로리(kcal) = 체중(kg) × METs × 시간(h) × 1.05
+ *
+ * METs 값 (속도 기준):
+ * - 걷기 (< 6 km/h):      METs 3.5
+ * - 조깅 (6 ~ 8 km/h):    METs 7.0
+ * - 러닝 (8 ~ 10 km/h):   METs 9.0
+ * - 빠른 러닝 (≥ 10 km/h): METs 11.0
+ * </pre>
+ *
+ * <h3>🔍 계산 예시</h3>
+ * <pre>
+ * 예1) 70kg, 5km, 30분 (10 km/h) 러닝
+ *   → 속도 = 5km / 0.5h = 10 km/h → METs 9.0
+ *   → 칼로리 = 70 × 9.0 × 0.5 × 1.05 = 330.75 kcal
+ *
+ * 예2) 60kg, 1km, 14분 (4.3 km/h) 걷기
+ *   → 속도 = 1km / 0.233h = 4.3 km/h → METs 3.5
+ *   → 칼로리 = 60 × 3.5 × 0.233 × 1.05 = 51.4 kcal
+ * </pre>
+ *
+ * <h3>📱 프론트엔드 구현 가이드 (TypeScript/JavaScript)</h3>
+ * <pre>
+ * function calculateCalories(distanceKm: number, durationSeconds: number, weightKg: number): number {
+ *   if (distanceKm <= 0 || durationSeconds <= 0 || weightKg <= 0) {
+ *     return 0;
+ *   }
+ *
+ *   const durationHours = durationSeconds / 3600.0;
+ *   const speedKmh = distanceKm / durationHours;
+ *
+ *   let mets: number;
+ *   if (speedKmh < 6.0) {
+ *     mets = 3.5;  // 걷기
+ *   } else if (speedKmh < 8.0) {
+ *     mets = 7.0;  // 조깅
+ *   } else if (speedKmh < 10.0) {
+ *     mets = 9.0;  // 러닝
+ *   } else {
+ *     mets = 11.0; // 빠른 러닝
+ *   }
+ *
+ *   const calories = weightKg * mets * durationHours * 1.05;
+ *   return Math.round(calories);
+ * }
+ * </pre>
+ *
+ * <h3>⌚ 워치 구현 가이드 (Kotlin/Android)</h3>
+ * <pre>
+ * fun calculateCalories(distanceKm: Double, durationSeconds: Int, weightKg: Int): Int {
+ *   if (distanceKm <= 0 || durationSeconds <= 0 || weightKg <= 0) {
+ *     return 0
+ *   }
+ *
+ *   val durationHours = durationSeconds / 3600.0
+ *   val speedKmh = distanceKm / durationHours
+ *
+ *   val mets = when {
+ *     speedKmh < 6.0 -> 3.5  // 걷기
+ *     speedKmh < 8.0 -> 7.0  // 조깅
+ *     speedKmh < 10.0 -> 9.0  // 러닝
+ *     else -> 11.0           // 빠른 러닝
+ *   }
+ *
+ *   val calories = weightKg * mets * durationHours * 1.05
+ *   return calories.roundToInt()
+ * }
+ * </pre>
+ *
+ * @author WayToEarth Team
+ * @since 2025-01-09
+ */
+public class CalorieCalculator {
+
+    /**
+     * 칼로리 계산 (METs 기반)
+     *
+     * @param distanceKm      거리(km)
+     * @param durationSeconds 시간(초)
+     * @param weightKg        체중(kg)
+     * @return 소모 칼로리(kcal), 반올림된 정수
+     */
+    public static int calculate(double distanceKm, int durationSeconds, int weightKg) {
+        // 유효성 검증
+        if (distanceKm <= 0 || durationSeconds <= 0 || weightKg <= 0) {
+            return 0;
+        }
+
+        // 시간을 시간(hour) 단위로 변환
+        double durationHours = durationSeconds / 3600.0;
+
+        // 속도(km/h) 계산
+        double speedKmh = distanceKm / durationHours;
+
+        // 속도에 따른 METs 값 결정
+        double mets;
+        if (speedKmh < 6.0) {
+            mets = 3.5;  // 걷기
+        } else if (speedKmh < 8.0) {
+            mets = 7.0;  // 조깅
+        } else if (speedKmh < 10.0) {
+            mets = 9.0;  // 러닝
+        } else {
+            mets = 11.0; // 빠른 러닝
+        }
+
+        // 칼로리 계산: 체중(kg) × METs × 시간(h) × 1.05
+        double calories = weightKg * mets * durationHours * 1.05;
+
+        // 반올림하여 정수로 반환
+        return (int) Math.round(calories);
+    }
+
+    /**
+     * 속도(km/h) 계산 헬퍼 메서드
+     *
+     * @param distanceKm      거리(km)
+     * @param durationSeconds 시간(초)
+     * @return 속도(km/h)
+     */
+    public static double calculateSpeed(double distanceKm, int durationSeconds) {
+        if (distanceKm <= 0 || durationSeconds <= 0) {
+            return 0.0;
+        }
+        double durationHours = durationSeconds / 3600.0;
+        return distanceKm / durationHours;
+    }
+
+    /**
+     * METs 값 계산 헬퍼 메서드
+     *
+     * @param speedKmh 속도(km/h)
+     * @return METs 값
+     */
+    public static double getMets(double speedKmh) {
+        if (speedKmh < 6.0) {
+            return 3.5;  // 걷기
+        } else if (speedKmh < 8.0) {
+            return 7.0;  // 조깅
+        } else if (speedKmh < 10.0) {
+            return 9.0;  // 러닝
+        } else {
+            return 11.0; // 빠른 러닝
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #145 

 작업 목적

  - 사용자별 정확한 칼로리 계산을 위해 키/몸무게 정보 수집
  - 온보딩 단계에서 신체 정보 입력 기능 추가
  - 프론트/워치에서 동일하게 사용할 칼로리 계산 공식 표준화

  ---
  변경 사항

  1. User 엔티티 수정

  - height (키, cm) 필드 추가
  - weight (몸무게, kg) 필드 추가
  - completeOnboarding() 메서드에 height, weight 파라미터 추가

  2. 온보딩 API 수정

  - OnboardingRequest: 키/몸무게 입력 필드 추가
    - height: 100 ~ 250cm 유효성 검증
    - weight: 30 ~ 200kg 유효성 검증
  - UserInfoResponse: 키/몸무게 응답 필드 추가
  - UserService: 온보딩 로직에 height, weight 저장 추가

  3. CalorieCalculator 유틸 추가

  - METs(Metabolic Equivalent of Task) 기반 칼로리 계산 로직
  - 속도별 METs 값:
    - 걷기 (< 6 km/h): 3.5
    - 조깅 (6-8 km/h): 7.0
    - 러닝 (8-10 km/h): 9.0
    - 빠른 러닝 (≥ 10 km/h): 11.0
  - 프론트엔드/워치 개발자를 위한 상세 JavaDoc 및 구현 가이드 포함

  ---
  🔧 기술 스펙

  칼로리 계산 공식

  칼로리(kcal) = 체중(kg) × METs × 시간(h) × 1.05

  API 요청 예시

  POST /v1/auth/onboarding
  {
    "nickname": "홍러너",
    "residence": "서울특별시 강남구",
    "age_group": "TWENTIES",
    "gender": "MALE",
    "height": 175,
    "weight": 70,
    "weekly_goal_distance": 15.5,
    "profileImageKey": "profiles/123/profile.jpg"
  }

  API 응답 예시

  GET /v1/users/me
  {
    "id": 12345,
    "nickname": "홍러너",
    "height": 175,
    "weight": 70,
    ...
  }

  ---
  테스트

  - 빌드 성공 (./gradlew clean build -x test)
  - 컴파일 성공 (./gradlew compileJava)
  - 온보딩 API 테스트 (Postman/Swagger)
  - 칼로리 계산 로직 검증

  ---
  프론트엔드 작업 필요 사항

  1. 온보딩 화면 수정

  - 키 입력 필드 추가 (100-250cm)
  - 몸무게 입력 필드 추가 (30-200kg)

  2. 칼로리 계산 로직 적용

  - CalorieCalculator.java의 JavaDoc에 포함된 TypeScript/Kotlin 코드 참고
  - 동일한 METs 기반 계산식 사용

  3. API 요청 수정

  - 온보딩 요청에 height, weight 필드 추가

  ---
  워치 작업 필요 사항 (추후)

  - CalorieCalculator JavaDoc의 Kotlin 구현 코드 참고
  - 동일한 METs 기반 계산식 적용

  ---
  관련 이슈

  - 칼로리 계산 로직 개선 (#이슈번호)

  ---
  체크리스트

  - User 엔티티 height, weight 필드 추가
  - 온보딩 Request/Response DTO 수정
  - UserService 로직 수정
  - CalorieCalculator 유틸 작성
  - 빌드 테스트 통과
  - API 문서 업데이트 (Swagger)
  - 프론트엔드 개발자에게 계산 공식 전달

  ---
  추가 노트

  현재 아키텍처 유지:
  - 거리/시간/페이스: 프론트 계산 → 백엔드 저장 (기존 방식 유지)
  - 칼로리: 프론트 계산 → 백엔드 저장 (동일한 방식)
  - 백엔드는 필요 시 CalorieCalculator로 검증 가능 (옵션)

  프론트/워치 개발자 참고:
  src/main/java/com/waytoearth/util/CalorieCalculator.java 파일의 상세한 JavaDoc을 확인하세요. TypeScript와 Kotlin 구현 예제가 포함되어 있습니다.
