### PR TITLE
feat: 실시간 페이스 코치 기능 구현

### DIFF
--- a/src/main/java/com/waytoearth/controller/v1/running/PaceCoachController.java
+++ b/src/main/java/com/waytoearth/controller/v1/running/PaceCoachController.java
@@ -1,0 +1,60 @@
+package com.waytoearth.controller.v1.running;
+
+import com.waytoearth.dto.request.running.PaceCoachCheckRequest;
+import com.waytoearth.dto.response.common.ApiResponse;
+import com.waytoearth.dto.response.running.PaceCoachCheckResponse;
+import com.waytoearth.security.AuthUser;
+import com.waytoearth.security.AuthenticatedUser;
+import com.waytoearth.service.running.PaceCoachService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "실시간 페이스 코치 API", description = "러닝 중 페이스 체크 및 알림")
+@RestController
+@RequestMapping("/v1/running/pace-coach")
+@RequiredArgsConstructor
+public class PaceCoachController {
+
+    private final PaceCoachService paceCoachService;
+
+    @Operation(
+            summary = "페이스 코치 체크",
+            description = """
+                    러닝 중 km를 통과할 때마다 호출하여 페이스를 체크합니다.
+
+                    **동작 방식:**
+                    - 설정에서 "AI 페이스 코치"가 OFF면 비활성화 응답
+                    - 완료된 러닝 기록이 5회 미만이면 사용 불가 응답
+                    - 5회 이상이면 최근 5회 평균 페이스 계산
+                    - 현재 페이스와 비교하여 느리면 알림 필요 (shouldAlert: true)
+                    - 빠르거나 같으면 알림 불필요 (shouldAlert: false)
+
+                    **호출 시점:**
+                    - 프론트엔드가 러닝 중 1km, 2km, 3km... 통과할 때마다 호출
+
+                    **응답 필드:**
+                    - `shouldAlert`: true면 팝업 띄우기, false면 무시
+                    - `alertMessage`: 팝업에 표시할 메시지
+                    """
+    )
+    @PostMapping("/check")
+    public ResponseEntity<ApiResponse<PaceCoachCheckResponse>> checkPace(
+            @AuthUser AuthenticatedUser user,
+            @Valid @RequestBody PaceCoachCheckRequest request) {
+
+        PaceCoachCheckResponse response = paceCoachService.checkPace(
+                user.getUserId(),
+                request.getSessionId(),
+                request.getCurrentKm(),
+                request.getCurrentPaceSeconds()
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "페이스 코치 체크 완료")
+        );
+    }
+}

--- a/src/main/java/com/waytoearth/dto/request/running/PaceCoachCheckRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/running/PaceCoachCheckRequest.java
@@ -1,0 +1,36 @@
+package com.waytoearth.dto.request.running;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "페이스 코치 체크 요청")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaceCoachCheckRequest {
+
+    @Schema(description = "러닝 세션 ID", example = "running-session-123", required = true)
+    @NotBlank(message = "세션 ID는 필수입니다")
+    @JsonProperty("session_id")
+    private String sessionId;
+
+    @Schema(description = "현재 통과한 km", example = "2", required = true)
+    @NotNull(message = "현재 km는 필수입니다")
+    @Min(value = 1, message = "km는 1 이상이어야 합니다")
+    @JsonProperty("current_km")
+    private Integer currentKm;
+
+    @Schema(description = "현재 페이스 (초/km)", example = "380", required = true)
+    @NotNull(message = "현재 페이스는 필수입니다")
+    @Min(value = 1, message = "페이스는 1초 이상이어야 합니다")
+    @JsonProperty("current_pace_seconds")
+    private Integer currentPaceSeconds;
+}

--- a/src/main/java/com/waytoearth/dto/request/user/UserUpdateRequest.java
+++ b/src/main/java/com/waytoearth/dto/request/user/UserUpdateRequest.java
@@ -33,6 +33,9 @@ public class UserUpdateRequest {
         @DecimalMax(value = "999.99")
         private BigDecimal weeklyGoalDistance;
 
+        @JsonProperty("is_pace_coach_enabled")
+        private Boolean isPaceCoachEnabled;
+
         //  S3 key도 함께 전달 (삭제/교체 시 필요)
         @JsonProperty("profile_image_key")
         private String profileImageKey;

--- a/src/main/java/com/waytoearth/dto/response/running/PaceCoachCheckResponse.java
+++ b/src/main/java/com/waytoearth/dto/response/running/PaceCoachCheckResponse.java
@@ -1,0 +1,66 @@
+package com.waytoearth.dto.response.running;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "페이스 코치 체크 응답")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PaceCoachCheckResponse {
+
+    @Schema(description = "페이스 코치 활성화 여부", example = "true")
+    @JsonProperty("coach_enabled")
+    private Boolean coachEnabled;
+
+    @Schema(description = "사용 가능 여부 (5회 이상)", example = "true")
+    @JsonProperty("is_available")
+    private Boolean isAvailable;
+
+    @Schema(description = "알림을 띄워야 하는지 (느릴 때만 true)", example = "true")
+    @JsonProperty("should_alert")
+    private Boolean shouldAlert;
+
+    @Schema(description = "기준 평균 페이스 (초/km)", example = "360")
+    @JsonProperty("reference_pace_seconds")
+    private Integer referencePaceSeconds;
+
+    @Schema(description = "기준 평균 페이스 (포맷)", example = "6:00/km")
+    @JsonProperty("reference_pace_formatted")
+    private String referencePaceFormatted;
+
+    @Schema(description = "현재 페이스 (초/km)", example = "380")
+    @JsonProperty("current_pace_seconds")
+    private Integer currentPaceSeconds;
+
+    @Schema(description = "현재 페이스 (포맷)", example = "6:20/km")
+    @JsonProperty("current_pace_formatted")
+    private String currentPaceFormatted;
+
+    @Schema(description = "페이스 차이 (초)", example = "20")
+    @JsonProperty("difference_seconds")
+    private Integer differenceSeconds;
+
+    @Schema(description = "알림 메시지", example = "평균보다 20초 느려요! 조금만 더 힘내세요!")
+    @JsonProperty("alert_message")
+    private String alertMessage;
+
+    @Schema(description = "최소 필요 러닝 기록 수", example = "5")
+    @JsonProperty("minimum_records_required")
+    private Integer minimumRecordsRequired;
+
+    @Schema(description = "현재 러닝 기록 수", example = "3")
+    @JsonProperty("current_records")
+    private Integer currentRecords;
+
+    @Schema(description = "안내 메시지", example = "페이스 코치는 5회 이상 러닝 후 사용 가능합니다")
+    @JsonProperty("message")
+    private String message;
+}

--- a/src/main/java/com/waytoearth/entity/user/User.java
+++ b/src/main/java/com/waytoearth/entity/user/User.java
@@ -52,6 +52,11 @@ public class User extends BaseTimeEntity {
     private BigDecimal weeklyGoalDistance;
 
     @Setter
+    @Column(name = "is_pace_coach_enabled", nullable = false)
+    @Builder.Default
+    private Boolean isPaceCoachEnabled = false;
+
+    @Setter
     @Column(name = "profile_image_url", length = 2048)
     private String profileImageUrl;
 

--- a/src/main/java/com/waytoearth/service/running/PaceCoachService.java
+++ b/src/main/java/com/waytoearth/service/running/PaceCoachService.java
@@ -58,7 +58,7 @@ public class PaceCoachService {
         }
 
         // 3. 완료된 러닝 기록 수 확인
-        long completedCount = getCompletedRecordsCount(userId);
+        long completedCount = getCompletedRecordsCount(user);
         log.debug("Completed records count: {}", completedCount);
 
         if (completedCount < MINIMUM_RECORDS_REQUIRED) {
@@ -121,8 +121,8 @@ public class PaceCoachService {
     /**
      * 완료된 러닝 기록 수 조회
      */
-    private long getCompletedRecordsCount(Long userId) {
-        return runningRecordRepository.countByUserIdAndIsCompletedTrue(userId);
+    private long getCompletedRecordsCount(User user) {
+        return runningRecordRepository.countByUserAndIsCompletedTrue(user);
     }
 
     /**

--- a/src/main/java/com/waytoearth/service/running/PaceCoachService.java
+++ b/src/main/java/com/waytoearth/service/running/PaceCoachService.java
@@ -1,0 +1,170 @@
+package com.waytoearth.service.running;
+
+import com.waytoearth.dto.response.running.PaceCoachCheckResponse;
+import com.waytoearth.entity.running.RunningRecord;
+import com.waytoearth.entity.user.User;
+import com.waytoearth.exception.UserNotFoundException;
+import com.waytoearth.repository.running.RunningRecordRepository;
+import com.waytoearth.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 실시간 페이스 코치 서비스
+ * - 러닝 중 km마다 페이스 체크
+ * - 평균보다 느릴 때 알림
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaceCoachService {
+
+    private final RunningRecordRepository runningRecordRepository;
+    private final UserRepository userRepository;
+
+    private static final int MINIMUM_RECORDS_REQUIRED = 5;
+    private static final int RECENT_RECORDS_LIMIT = 5;
+
+    /**
+     * 페이스 코치 체크
+     * - 실시간으로 현재 페이스를 평균과 비교
+     *
+     * @param userId              사용자 ID
+     * @param sessionId           러닝 세션 ID
+     * @param currentKm           현재 통과한 km
+     * @param currentPaceSeconds  현재 페이스 (초/km)
+     * @return 페이스 체크 결과
+     */
+    @Transactional(readOnly = true)
+    public PaceCoachCheckResponse checkPace(Long userId, String sessionId,
+                                             Integer currentKm, Integer currentPaceSeconds) {
+        log.info("Pace coach check - userId: {}, km: {}, pace: {}s", userId, currentKm, currentPaceSeconds);
+
+        // 1. User 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다: " + userId));
+
+        // 2. 페이스 코치 활성화 여부 확인
+        if (!Boolean.TRUE.equals(user.getIsPaceCoachEnabled())) {
+            log.debug("Pace coach disabled for user: {}", userId);
+            return PaceCoachCheckResponse.builder()
+                    .coachEnabled(false)
+                    .message("페이스 코치가 비활성화되어 있습니다")
+                    .build();
+        }
+
+        // 3. 완료된 러닝 기록 수 확인
+        long completedCount = getCompletedRecordsCount(userId);
+        log.debug("Completed records count: {}", completedCount);
+
+        if (completedCount < MINIMUM_RECORDS_REQUIRED) {
+            return PaceCoachCheckResponse.builder()
+                    .coachEnabled(true)
+                    .isAvailable(false)
+                    .minimumRecordsRequired(MINIMUM_RECORDS_REQUIRED)
+                    .currentRecords((int) completedCount)
+                    .message(String.format("페이스 코치는 %d회 이상 러닝 후 사용 가능합니다 (현재: %d회)",
+                            MINIMUM_RECORDS_REQUIRED, completedCount))
+                    .build();
+        }
+
+        // 4. 최근 N회 평균 페이스 계산
+        Integer averagePace = calculateRecentAveragePace(userId, RECENT_RECORDS_LIMIT);
+        if (averagePace == null || averagePace == 0) {
+            log.warn("Cannot calculate average pace for user: {}", userId);
+            return PaceCoachCheckResponse.builder()
+                    .coachEnabled(true)
+                    .isAvailable(false)
+                    .message("평균 페이스를 계산할 수 없습니다")
+                    .build();
+        }
+
+        // 5. 현재 페이스와 비교
+        int difference = currentPaceSeconds - averagePace;
+        log.debug("Pace comparison - average: {}s, current: {}s, difference: {}s",
+                averagePace, currentPaceSeconds, difference);
+
+        // 6. 느리면 알림 필요
+        if (difference > 0) {
+            // 평균보다 느림
+            String alertMessage = String.format("평균보다 %d초 느려요! 조금만 더 힘내세요!", difference);
+            return PaceCoachCheckResponse.builder()
+                    .coachEnabled(true)
+                    .isAvailable(true)
+                    .shouldAlert(true)
+                    .referencePaceSeconds(averagePace)
+                    .referencePaceFormatted(formatPace(averagePace))
+                    .currentPaceSeconds(currentPaceSeconds)
+                    .currentPaceFormatted(formatPace(currentPaceSeconds))
+                    .differenceSeconds(difference)
+                    .alertMessage(alertMessage)
+                    .build();
+        } else {
+            // 평균보다 빠르거나 같음 - 알림 없음
+            return PaceCoachCheckResponse.builder()
+                    .coachEnabled(true)
+                    .isAvailable(true)
+                    .shouldAlert(false)
+                    .referencePaceSeconds(averagePace)
+                    .referencePaceFormatted(formatPace(averagePace))
+                    .currentPaceSeconds(currentPaceSeconds)
+                    .currentPaceFormatted(formatPace(currentPaceSeconds))
+                    .differenceSeconds(difference)
+                    .build();
+        }
+    }
+
+    /**
+     * 완료된 러닝 기록 수 조회
+     */
+    private long getCompletedRecordsCount(Long userId) {
+        return runningRecordRepository.countByUserIdAndIsCompletedTrue(userId);
+    }
+
+    /**
+     * 최근 N회 평균 페이스 계산
+     *
+     * @param userId 사용자 ID
+     * @param limit  최근 기록 개수
+     * @return 평균 페이스 (초/km), 계산 불가 시 null
+     */
+    private Integer calculateRecentAveragePace(Long userId, int limit) {
+        List<RunningRecord> recentRecords = runningRecordRepository
+                .findAllByUserIdAndIsCompletedTrueOrderByStartedAtDesc(userId)
+                .stream()
+                .limit(limit)
+                .toList();
+
+        if (recentRecords.isEmpty()) {
+            return null;
+        }
+
+        double averagePace = recentRecords.stream()
+                .map(RunningRecord::getAveragePaceSeconds)
+                .filter(pace -> pace != null && pace > 0)
+                .mapToInt(Integer::intValue)
+                .average()
+                .orElse(0.0);
+
+        return averagePace > 0 ? (int) Math.round(averagePace) : null;
+    }
+
+    /**
+     * 페이스를 "분:초/km" 형식으로 변환
+     *
+     * @param paceSeconds 페이스 (초/km)
+     * @return 포맷된 문자열 (예: "6:20/km")
+     */
+    private String formatPace(Integer paceSeconds) {
+        if (paceSeconds == null || paceSeconds == 0) {
+            return "측정 안됨";
+        }
+        int minutes = paceSeconds / 60;
+        int seconds = paceSeconds % 60;
+        return String.format("%d:%02d/km", minutes, seconds);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #150 

  ##  개요
  러닝 중 실시간으로 페이스를 체크하여 평균보다 느릴 때 사용자에게 알림을 제공하는 기능을 구현했습니다.

  ## 구현 목적
  - 사용자가 러닝 중 페이스 조절을 할 수 있도록 실시간 피드백 제공
  - 최근 5회 평균 페이스를 기준으로 현재 페이스 비교
  - km 통과 시마다 자동으로 체크하여 느려진 경우에만 알림

  ##  주요 기능
  - **설정 ON/OFF**: 사용자가 설정에서 페이스 코치 활성화/비활성화 가능
  - **실시간 체크**: 러닝 중 km마다 페이스 자동 체크
  - **평균 기반 판단**: 최근 5회 완료된 러닝의 평균 페이스 계산
  - **조건부 알림**: 평균보다 느릴 때만 알림 (빠르거나 같으면 알림 없음)
  - **최소 기록 요구**: 5회 이상 러닝 완료 후부터 사용 가능

  ##  변경 사항

  ### 1. Entity 수정
  - **User.java**
    - `isPaceCoachEnabled` 필드 추가 (Boolean, 기본값: false)
    - 사용자별 페이스 코치 설정 관리

  ### 2. DTO 수정/생성
  - **UserUpdateRequest.java**
    - `isPaceCoachEnabled` 필드 추가
    - 사용자 설정 업데이트 시 페이스 코치 ON/OFF 가능

  - **PaceCoachCheckRequest.java** (신규)
    - 러닝 중 페이스 체크 요청 DTO
    - 필드: `sessionId`, `currentKm`, `currentPaceSeconds`

  - **PaceCoachCheckResponse.java** (신규)
    - 페이스 체크 결과 응답 DTO
    - 알림 필요 여부(`shouldAlert`), 페이스 비교 결과 포함

  ### 3. Service 구현
  - **PaceCoachService.java** (신규)
    - 페이스 코치 핵심 로직
    - 기능:
      - 페이스 코치 활성화 여부 확인
      - 완료된 러닝 5회 이상 체크
      - 최근 5회 평균 페이스 계산
      - 현재 페이스와 비교하여 알림 필요 여부 판단
      - 페이스 포맷팅 유틸리티

  ### 4. Controller 구현
  - **PaceCoachController.java** (신규)
    - API 엔드포인트: `POST /v1/running/pace-coach/check`
    - 인증된 사용자의 실시간 페이스 체크 요청 처리

  ## 🔌 API 스펙

  ### 엔드포인트
  POST /v1/running/pace-coach/check

  ### Request
  ```
  {
    "session_id": "running-session-123",
    "current_km": 2,
    "current_pace_seconds": 380
  }
```
  Response (페이스 느림)
```
  {
    "status": "success",
    "message": "페이스 코치 체크 완료",
    "data": {
      "coach_enabled": true,
      "is_available": true,
      "should_alert": true,
      "reference_pace_seconds": 360,
      "reference_pace_formatted": "6:00/km",
      "current_pace_seconds": 380,
      "current_pace_formatted": "6:20/km",
      "difference_seconds": 20,
      "alert_message": "평균보다 20초 느려요! 조금만 더 힘내세요!"
    }
  }
```
  Response (페이스 괜찮음)
```
  {
    "status": "success",
    "message": "페이스 코치 체크 완료",
    "data": {
      "coach_enabled": true,
      "is_available": true,
      "should_alert": false,
      "reference_pace_seconds": 360,
      "current_pace_seconds": 355,
      "difference_seconds": -5
    }
  }
```
  Response (5회 미만)
````
  {
    "status": "success",
    "message": "페이스 코치 체크 완료",
    "data": {
      "coach_enabled": true,
      "is_available": false,
      "minimum_records_required": 5,
      "current_records": 3,
      "message": "페이스 코치는 5회 이상 러닝 후 사용 가능합니다 (현재: 3회)"
    }
  }
````
   동작 플로우

  1. 앱에서 km 통과 시 API 호출
     ↓
  2. User 조회 및 isPaceCoachEnabled 확인
     ↓
  3. 완료된 러닝 기록 5회 이상 확인
     ↓
  4. 최근 5회 평균 페이스 계산
     ↓
  5. 현재 페이스와 비교
     ↓
  6. 느리면 shouldAlert: true 반환
     ↓
  7. 앱에서 팝업 표시

  🧪 테스트 방법

  1. 페이스 코치 비활성화 테스트

  ### User의 isPaceCoachEnabled = false 상태에서
  POST /v1/running/pace-coach/check
  {
    "session_id": "test-session",
    "current_km": 1,
    "current_pace_seconds": 360
  }

  # 예상 결과: coach_enabled: false

  2. 5회 미만 테스트

  # 완료된 러닝 기록이 3회인 사용자
  POST /v1/running/pace-coach/check

  # 예상 결과: is_available: false, current_records: 3

  3. 정상 작동 테스트 (느림)

  # 완료된 러닝 5회 이상, 평균 360초/km
  POST /v1/running/pace-coach/check
````
  {
    "session_id": "test-session",
    "current_km": 2,
    "current_pace_seconds": 380
  }
````
  # 예상 결과: should_alert: true, difference_seconds: 20

  4. 정상 작동 테스트 (빠름)

  # 완료된 러닝 5회 이상, 평균 360초/km
````
  POST /v1/running/pace-coach/check
  {
    "session_id": "test-session",
    "current_km": 2,
    "current_pace_seconds": 350
  }
````
  # 예상 결과: should_alert: false, difference_seconds: -10

  📁 변경된 파일

  수정

  - src/main/java/com/waytoearth/entity/user/User.java
  - src/main/java/com/waytoearth/dto/request/user/UserUpdateRequest.java

  신규

  - src/main/java/com/waytoearth/dto/request/running/PaceCoachCheckRequest.java
  - src/main/java/com/waytoearth/dto/response/running/PaceCoachCheckResponse.java
  - src/main/java/com/waytoearth/service/running/PaceCoachService.java
  - src/main/java/com/waytoearth/controller/v1/running/PaceCoachController.java

  ✅ 체크리스트

  - User 엔티티에 isPaceCoachEnabled 필드 추가
  - UserUpdateRequest DTO 수정
  - Request/Response DTO 생성
  - PaceCoachService 핵심 로직 구현
  - PaceCoachController API 엔드포인트 구현
  - 5회 미만 비활성화 로직 작동 확인
  - 평균 페이스 계산 로직 검증
  - 컴파일 성공 확인
  - Swagger 문서화 완료
  - 프론트엔드 연동 테스트 (프론트 구현 후)
  - DB 마이그레이션 스크립트 작성 (필요 시)

  💡 주요 구현 포인트

  1. 최소 5회 제한

  - 평균 페이스의 신뢰도 확보를 위해 5회 이상 완료된 기록 필요
  - 5회 미만 시 명확한 안내 메시지 제공

  2. 평균 계산 방식

  - 최근 5회 완료된 러닝의 averagePaceSeconds 평균 사용
  - null 체크 및 0 이하 값 필터링

  3. 알림 조건

  - 차이 = 현재 페이스 - 평균 페이스
  - 차이 > 0 (느림) → 알림
  - 차이 <= 0 (빠르거나 같음) → 알림 없음

  4. 페이스 포맷팅

  - 초 단위를 "분:초/km" 형식으로 변환
  - 예: 380초 → "6:20/km"



  📌 참고사항

  - AI라는 이름이 붙어있지만 실제로는 단순 계산 로직 (OpenAI 사용 안 함)
  - 기존 AI 복기 기능(RunningAnalysisService)은 수정하지 않음
  - 프론트엔드 구현 가이드 별도 전달 예정

  🚀 배포 시 주의사항

  - DB에 is_pace_coach_enabled 컬럼 추가 필요
  ALTER TABLE users ADD COLUMN is_pace_coach_enabled TINYINT(1) NOT NULL DEFAULT 0;
  - 기존 사용자는 기본값 false로 시작 (사용자가 직접 ON 필요)
